### PR TITLE
fix(recording): validate movie finalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-12
 
+- Required completed `AVAssetWriter` finalization before persisting recording
+  history, removed failed partial movies, and cleared recorder input state.
+- Added static contracts and a maintenance plan for the recording finalization
+  boundary.
 - Removed the force unwrap from recorder handoff and added static identity
   coverage for capture startup.
 

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -86,6 +86,10 @@ class CaptureEngine: NSObject, @unchecked Sendable {
         }
         powerMeter.processSilence()
         self.movie.stopRecording { [self] url in
+            guard let url = url else {
+                return
+            }
+
             // save to CoreData
             let endTime = Date()
 

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -76,15 +76,24 @@ class MovieRecorder {
         isRecording = true
     }
 
-    func stopRecording(completion: @escaping (URL) -> Void) {
+    func stopRecording(completion: @escaping (URL?) -> Void) {
+        let assetWriter = self.assetWriter
+        isRecording = false
+        self.assetWriter = nil
+        assetWriterAudioInput = nil
+        assetWriterVideoInput = nil
+
         guard let assetWriter = assetWriter else {
+            completion(nil)
             return
         }
 
-        self.isRecording = false
-        self.assetWriter = nil
-
         assetWriter.finishWriting {
+            guard assetWriter.status == .completed else {
+                try? FileManager.default.removeItem(at: assetWriter.outputURL)
+                completion(nil)
+                return
+            }
             completion(assetWriter.outputURL)
         }
     }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   metering and reset the visible timer.
 - Static behavior checks also require capture setup failures to cancel the
   movie writer and remove its unfinished file.
+- Static behavior checks require recording finalization to return only
+  completed movie URLs, remove failed partial files, and skip recording-history
+  persistence when no completed URL exists.
 - Static behavior checks require the capture engine and stream output recorder
   handoff to preserve caller identity without a force unwrap.
 - Static project checks require the Xcode project to leave `DEVELOPMENT_TEAM`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,8 @@ Helpful reports include:
   development team, certificate, capture permission, or recording data.
 - Capture setup failures must cancel unfinished movie writers and remove their
   partial local files without saving recording metadata.
+- Recording finalization persists history only after the asset writer reports
+  completion; failed partial files are removed without logging their URLs.
 - The capture engine and stream output use the caller-provided recorder handoff
   directly, avoiding a force unwrap in the recording startup path.
 

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,8 @@ Priority:
 - Keep the menu bar recording timer reset after recording stops
 - Clean up audio metering and timer state when recording start fails
 - Remove unfinished movie files when capture setup fails
+- Persist recording history only after successful movie finalization and remove
+  failed partial outputs
 - Keep recorder handoff identity explicit and force-unwrap-free
 - Keep local Xcode signing team choices out of checked-in project metadata
 - Avoid ad hoc stdout debug logging from app Swift sources

--- a/docs/plans/2026-06-12-recording-finalization-integrity.md
+++ b/docs/plans/2026-06-12-recording-finalization-integrity.md
@@ -1,0 +1,109 @@
+# Recording Finalization Integrity
+
+## Status: Completed
+
+## Context
+
+`MovieRecorder.stopRecording` currently invokes its completion with the output
+URL after `AVAssetWriter.finishWriting`, regardless of whether the writer
+actually completed. `CaptureEngine.stopCapture` treats every callback URL as a
+valid movie and persists a `VideoEntry`, which can leave failed or partial
+files in Documents and invalid entries in recording history.
+
+## Priority
+
+Only a successfully finalized movie should become durable recording metadata.
+Failed finalization must clean up the partial local file without exposing its
+URL as a completed recording.
+
+## Requirements
+
+- R1. Make recording finalization invoke its completion exactly once and report
+  the output URL only when the asset writer reaches `.completed`; report no URL
+  when no writer is active or finalization fails.
+- R2. Clear the recorder's writer and input references when stopping so stale
+  state cannot leak into a later recording.
+- R3. Remove the partial output file when finalization does not complete.
+- R4. Skip `VideoEntry` creation and persistence when finalization reports no
+  completed URL.
+- R5. Preserve the successful recording path, including `absoluteString`
+  metadata storage and existing start/end timestamps.
+- R6. Protect the behavior with source contracts, focused hostile mutations,
+  repository documentation, and the full `make check` gate.
+- R7. Do not log failed recording file URLs or other captured-content metadata.
+
+## Scope Boundaries
+
+- Do not change recording destinations, codecs, capture filters, or permission
+  behavior.
+- Do not redesign Core Data storage or add network reporting.
+- Do not claim interactive recording verification without running the app on a
+  compatible macOS host with Screen Recording permission.
+
+## Implementation Units
+
+### Recorder finalization contract
+
+**Files:** `CaptureSample/Record.swift`
+
+- Return an optional completed URL from the stop callback.
+- Complete the callback with no URL when there is no active writer.
+- Clear writer and input references before asynchronous finalization returns.
+- Check the terminal writer status and delete the output on failure.
+
+### Metadata persistence boundary
+
+**Files:** `CaptureSample/CaptureEngine.swift`
+
+- Require a non-nil completed URL before creating a `VideoEntry`.
+- Preserve the existing completed-recording metadata fields and save path.
+
+### Regression contracts and maintenance record
+
+**Files:** `scripts/check-capture-source.py`, `README.md`, `SECURITY.md`,
+`VISION.md`, `CHANGES.md`, `docs/plans/2026-06-12-recording-finalization-integrity.md`
+
+- Require the optional completion contract, terminal success check, failure
+  cleanup, state cleanup, and guarded persistence.
+- Document the completed-only recording history boundary and validation limits.
+
+## Verification Plan
+
+- `python3 scripts/check-capture-source.py --mode project`
+- `python3 scripts/check-capture-source.py --mode behavior`
+- `make check`
+- `make build`
+- focused finalization and persistence hostile mutations
+- `git diff --check`
+- exact-head hosted macOS unsigned build before merge
+
+## Work Completed
+
+- Made `MovieRecorder.stopRecording` complete exactly once with an optional
+  URL, clearing recorder state before handling either active or absent writers.
+- Required terminal `.completed` writer status before returning a movie URL and
+  removed the partial output for every other terminal result.
+- Guarded `VideoEntry` creation on a completed recording URL while preserving
+  existing timestamps and `absoluteString` persistence.
+- Extended source contracts and maintenance guidance for the finalization
+  boundary.
+
+## Verification
+
+- `python3 scripts/check-capture-source.py --mode behavior` passed.
+- Eight focused hostile finalization and persistence mutations were rejected.
+- `python3 -m py_compile scripts/check-capture-source.py` passed.
+- `make check` passed with project and behavior checks; local Xcode compilation
+  was unavailable on Linux and was explicitly skipped by the Makefile.
+- An external-directory invocation of the repository Makefile passed from
+  `/tmp`, proving the gate is independent of the caller's working directory.
+- Plan-aware correctness, maintainability, project-standards, testing,
+  reliability, and Swift lifecycle review found no actionable issues.
+- `git diff --check` passed.
+
+## Remaining Risks
+
+- Static contracts and compilation do not exercise disk-full, encoder, sleep,
+  or display-disconnect failures at runtime.
+- Interactive capture still requires a compatible macOS host, Screen Recording
+  permission, and manual inspection of recording history and partial files.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -12,6 +12,7 @@ TIMER_RESET_PLAN = DOCS_PLANS / "2026-06-09-recording-timer-reset.md"
 CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
 HOSTED_BUILD_PLAN = DOCS_PLANS / "2026-06-10-hosted-macos-build.md"
 RECORDER_HANDOFF_PLAN = DOCS_PLANS / "2026-06-12-recorder-handoff-identity.md"
+RECORDING_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-12-recording-finalization-integrity.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -55,6 +56,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-10-hosted-macos-build.md is missing")
     if not RECORDER_HANDOFF_PLAN.exists():
         errors.append("docs/plans/2026-06-12-recorder-handoff-identity.md is missing")
+    if not RECORDING_FINALIZATION_PLAN.exists():
+        errors.append("docs/plans/2026-06-12-recording-finalization-integrity.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -204,6 +207,20 @@ def behavior_checks():
         errors.append("MovieRecorder cancellation must cancel the writer and remove its partial file")
     if "self.movie.cancelRecording()\n                continuation.finish(throwing: error)" not in capture_engine:
         errors.append("CaptureEngine start failures must cancel the partial movie before finishing")
+    if "func stopRecording(completion: @escaping (URL?) -> Void)" not in record:
+        errors.append("MovieRecorder stop completion must distinguish completed and failed output URLs")
+    if "let assetWriter = self.assetWriter\n        isRecording = false\n        self.assetWriter = nil\n        assetWriterAudioInput = nil\n        assetWriterVideoInput = nil\n\n        guard let assetWriter = assetWriter else" not in record:
+        errors.append("MovieRecorder stop must clear all recorder state before handling an absent writer")
+    if "guard let assetWriter = assetWriter else {\n            completion(nil)\n            return\n        }" not in record:
+        errors.append("MovieRecorder stop must complete with no URL when no writer is active")
+    if "guard assetWriter.status == .completed else {" not in record:
+        errors.append("MovieRecorder stop must require completed writer status before returning an output URL")
+    if record.count("completion(nil)") < 2:
+        errors.append("MovieRecorder stop must report both absent-writer and failed-finalization outcomes")
+    if "guard assetWriter.status == .completed else {\n                try? FileManager.default.removeItem(at: assetWriter.outputURL)" not in record:
+        errors.append("MovieRecorder stop must remove the partial output when finalization fails")
+    if "guard let url = url else {\n                return\n            }\n\n            // save to CoreData" not in capture_engine:
+        errors.append("CaptureEngine must not persist metadata without a completed recording URL")
     if "url.description" in capture_engine:
         errors.append("CaptureEngine must persist recording URLs with absoluteString, not description")
     if "videoEntry.url = url.absoluteString" not in capture_engine:


### PR DESCRIPTION
## Summary

Failed movie finalization no longer creates a recording-history entry that points at a partial or unusable file. The recorder now reports a URL only after `AVAssetWriter` reaches `.completed`, clears retained writer state on every stop path, and removes failed output files without logging their locations.

## Baseline

The prior recording path could expose an output URL before movie finalization had proved the file usable, allowing persistence to create a history entry for failed or partial output. Retained writer state and failed files also needed deterministic cleanup. This is a stacked successor targeting the existing remediation branch rather than the default branch.

## Improvements

- report a recording URL only after `AVAssetWriter` reaches `.completed`
- clear retained writer state on every stop path
- remove failed output files without logging their locations
- treat the optional URL as the persistence boundary
- preserve successful recordings' existing timestamps and `absoluteString` storage
- create no Core Data entry when the writer is absent or finalization fails

## Validation

- `make check`
- external-directory repository Makefile check from `/tmp`
- Python 3.12 source-checker compilation
- eight focused hostile mutations covering callback, state, status, cleanup, and persistence regressions
- plan-aware correctness, maintainability, project-standards, testing, reliability, and Swift lifecycle review: no actionable findings
- two hosted `contract` checks and two hosted macOS `build` checks succeeded

## Risk

- This stacked PR depends on the existing ScreenRecorderMacOS remediation branch and must be integrated in the correct order.
- Local Xcode execution is unavailable on Linux, so runtime behavior still requires a compatible macOS manual check.
- Cleanup failure could leave a partial output file even though persistence correctly omits the history entry.
- The sample app has no production telemetry or deployed monitoring service.

## Follow-Ups

- Run the app on a compatible macOS host and confirm successful recordings appear in history.
- Induce writer finalization failure and confirm it leaves neither Core Data metadata nor a partial movie.
- Treat any hosted build failure, unexpected history entry, or retained partial output as a rollback trigger before merge.

## Post-Deploy Monitoring & Validation

No additional production monitoring is available or required because this is a local sample app with no telemetry or deployed service. During the PR validation window, the maintainer owns verification of the exact-head GitHub Actions contract and macOS build jobs; a compatible macOS manual run should confirm that successful recordings appear in history and an induced writer failure leaves neither metadata nor a partial movie. Any hosted build failure, unexpected history entry, or retained partial output is a rollback trigger for this commit before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
