### PR TITLE
fix(recording): await movie finalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Added awaited recording finalization so capture stop returns only after movie
+  validation and recording-history persistence complete.
+
 ## 2026-06-12
 
 - Required completed `AVAssetWriter` finalization before persisting recording

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -85,22 +85,20 @@ class CaptureEngine: NSObject, @unchecked Sendable {
             continuation?.finish(throwing: error)
         }
         powerMeter.processSilence()
-        self.movie.stopRecording { [self] url in
-            guard let url = url else {
-                return
-            }
-
-            // save to CoreData
-            let endTime = Date()
-
-            let videoEntry = VideoEntry(context: DataController.shared.moc)
-            videoEntry.id = UUID()
-            videoEntry.url = url.absoluteString
-            videoEntry.startTime = self.startTime
-            videoEntry.endTime = endTime
-            DataController.shared.save()
-
+        guard let url = await self.movie.stopRecording() else {
+            return
         }
+
+        // save to CoreData
+        let endTime = Date()
+
+        let videoEntry = VideoEntry(context: DataController.shared.moc)
+        videoEntry.id = UUID()
+        videoEntry.url = url.absoluteString
+        videoEntry.startTime = self.startTime
+        videoEntry.endTime = endTime
+        DataController.shared.save()
+
     }
 
     /// - Tag: UpdateStreamConfiguration

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -76,7 +76,7 @@ class MovieRecorder {
         isRecording = true
     }
 
-    func stopRecording(completion: @escaping (URL?) -> Void) {
+    func stopRecording() async -> URL? {
         let assetWriter = self.assetWriter
         isRecording = false
         self.assetWriter = nil
@@ -84,17 +84,18 @@ class MovieRecorder {
         assetWriterVideoInput = nil
 
         guard let assetWriter = assetWriter else {
-            completion(nil)
-            return
+            return nil
         }
 
-        assetWriter.finishWriting {
-            guard assetWriter.status == .completed else {
-                try? FileManager.default.removeItem(at: assetWriter.outputURL)
-                completion(nil)
-                return
+        return await withCheckedContinuation { continuation in
+            assetWriter.finishWriting {
+                guard assetWriter.status == .completed else {
+                    try? FileManager.default.removeItem(at: assetWriter.outputURL)
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: assetWriter.outputURL)
             }
-            completion(assetWriter.outputURL)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Static behavior checks require recording finalization to return only
   completed movie URLs, remove failed partial files, and skip recording-history
   persistence when no completed URL exists.
+- Static behavior checks require awaited recording finalization so the recorder
+  does not publish idle state before movie validation and persistence finish.
 - Static behavior checks require the capture engine and stream output recorder
   handoff to preserve caller identity without a force unwrap.
 - Static project checks require the Xcode project to leave `DEVELOPMENT_TEAM`
@@ -140,6 +142,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   cleanup when capture setup fails.
 - See `docs/plans/2026-06-12-recorder-handoff-identity.md` for the force-unwrap-
   free recorder handoff contract.
+- See `docs/plans/2026-06-13-awaited-recording-finalization.md` for the awaited
+  recording finalization and persistence boundary.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,8 @@ Helpful reports include:
   partial local files without saving recording metadata.
 - Recording finalization persists history only after the asset writer reports
   completion; failed partial files are removed without logging their URLs.
+- Awaited recording finalization keeps stop completion and idle-state publication
+  behind movie validation and recording-history persistence.
 - The capture engine and stream output use the caller-provided recorder handoff
   directly, avoiding a force unwrap in the recording startup path.
 

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Remove unfinished movie files when capture setup fails
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs
+- Keep awaited recording finalization ahead of recorder idle state
 - Keep recorder handoff identity explicit and force-unwrap-free
 - Keep local Xcode signing team choices out of checked-in project metadata
 - Avoid ad hoc stdout debug logging from app Swift sources

--- a/docs/plans/2026-06-13-awaited-recording-finalization.md
+++ b/docs/plans/2026-06-13-awaited-recording-finalization.md
@@ -1,0 +1,56 @@
+# Awaited Recording Finalization
+
+## Status: Completed
+
+## Context
+
+`CaptureEngine.stopCapture()` started asynchronous `AVAssetWriter`
+finalization through a callback and returned immediately. `ScreenRecorder.stop()`
+could therefore publish idle state and reset its timer before the movie URL was
+validated and recording history was persisted.
+
+## Priority
+
+Stopping a recording is complete only when the writer has finalized or failed
+and the persistence decision is known. Returning earlier creates a race between
+UI state, playback history, and the output file lifecycle.
+
+## Objectives
+
+- Expose movie finalization as an async `URL?` result.
+- Await `AVAssetWriter.finishWriting` with a checked continuation.
+- Resume every absent-writer, failed-finalization, and completed-output path.
+- Keep failed partial-file cleanup and completed-status validation.
+- Persist metadata before `stopCapture()` returns to `ScreenRecorder.stop()`.
+- Add fail-closed source, documentation, and completed-plan contracts.
+
+## Work Completed
+
+- Replaced the escaping completion callback with `async -> URL?`.
+- Bridged `finishWriting` through `withCheckedContinuation`.
+- Awaited finalization in `CaptureEngine` before creating the Core Data entry.
+- Updated behavior checks and project guidance for the awaited boundary.
+
+## Verification
+
+- `python3 scripts/check-capture-source.py --mode behavior`
+- `make check` locally and from outside the repository root
+- focused async signature, await, continuation, failure, documentation, and
+  plan mutations
+- Python checker compilation, Swift delimiter, secret, artifact, and
+  `git diff --check` audits
+- hosted unsigned macOS compilation; runtime capture remains permission-bound
+
+Project and behavior checks plus full `make check` passed locally, with the
+documented static-only path because `xcodebuild` is unavailable. All six async
+signature, await, checked-continuation, failure-resume, documentation, and plan
+mutations were rejected. Python checker compilation and `git diff --check`
+passed. That compilation produced an untracked `scripts/__pycache__` artifact;
+it is excluded from this commit and left intact under the workspace preservation
+policy. Hosted unsigned compilation remains required on the exact PR head.
+
+## Scope Boundary
+
+This orders stop completion behind movie finalization and persistence. It does
+not add an XCTest target or exercise ScreenCaptureKit permission prompts,
+capture media, playback, or file-system failures in hosted CI.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -13,6 +13,7 @@ CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
 HOSTED_BUILD_PLAN = DOCS_PLANS / "2026-06-10-hosted-macos-build.md"
 RECORDER_HANDOFF_PLAN = DOCS_PLANS / "2026-06-12-recorder-handoff-identity.md"
 RECORDING_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-12-recording-finalization-integrity.md"
+AWAITED_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-13-awaited-recording-finalization.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -58,6 +59,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-12-recorder-handoff-identity.md is missing")
     if not RECORDING_FINALIZATION_PLAN.exists():
         errors.append("docs/plans/2026-06-12-recording-finalization-integrity.md is missing")
+    if not AWAITED_FINALIZATION_PLAN.exists():
+        errors.append("docs/plans/2026-06-13-awaited-recording-finalization.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -144,6 +147,8 @@ def project_checks():
             errors.append(f"{docs_file} must document the GitHub Actions baseline")
         if "recorder handoff" not in document:
             errors.append(f"{docs_file} must document the recorder handoff contract")
+        if "awaited recording finalization" not in document.lower():
+            errors.append(f"{docs_file} must document awaited recording finalization")
 
     entitlements = read_text("CaptureSample/CaptureSample.entitlements")
     if "<plist version=\"1.0\">" not in entitlements:
@@ -207,19 +212,21 @@ def behavior_checks():
         errors.append("MovieRecorder cancellation must cancel the writer and remove its partial file")
     if "self.movie.cancelRecording()\n                continuation.finish(throwing: error)" not in capture_engine:
         errors.append("CaptureEngine start failures must cancel the partial movie before finishing")
-    if "func stopRecording(completion: @escaping (URL?) -> Void)" not in record:
-        errors.append("MovieRecorder stop completion must distinguish completed and failed output URLs")
+    if "func stopRecording() async -> URL?" not in record:
+        errors.append("MovieRecorder stop must expose an awaitable completed-or-failed output URL")
     if "let assetWriter = self.assetWriter\n        isRecording = false\n        self.assetWriter = nil\n        assetWriterAudioInput = nil\n        assetWriterVideoInput = nil\n\n        guard let assetWriter = assetWriter else" not in record:
         errors.append("MovieRecorder stop must clear all recorder state before handling an absent writer")
-    if "guard let assetWriter = assetWriter else {\n            completion(nil)\n            return\n        }" not in record:
+    if "guard let assetWriter = assetWriter else {\n            return nil\n        }" not in record:
         errors.append("MovieRecorder stop must complete with no URL when no writer is active")
     if "guard assetWriter.status == .completed else {" not in record:
         errors.append("MovieRecorder stop must require completed writer status before returning an output URL")
-    if record.count("completion(nil)") < 2:
-        errors.append("MovieRecorder stop must report both absent-writer and failed-finalization outcomes")
-    if "guard assetWriter.status == .completed else {\n                try? FileManager.default.removeItem(at: assetWriter.outputURL)" not in record:
+    if "return await withCheckedContinuation { continuation in" not in record:
+        errors.append("MovieRecorder stop must await AVAssetWriter finalization")
+    if "continuation.resume(returning: nil)" not in record or "continuation.resume(returning: assetWriter.outputURL)" not in record:
+        errors.append("MovieRecorder stop must resume awaited finalization for failed and completed outputs")
+    if "guard assetWriter.status == .completed else {\n                    try? FileManager.default.removeItem(at: assetWriter.outputURL)" not in record:
         errors.append("MovieRecorder stop must remove the partial output when finalization fails")
-    if "guard let url = url else {\n                return\n            }\n\n            // save to CoreData" not in capture_engine:
+    if "guard let url = await self.movie.stopRecording() else {\n            return\n        }\n\n        // save to CoreData" not in capture_engine:
         errors.append("CaptureEngine must not persist metadata without a completed recording URL")
     if "url.description" in capture_engine:
         errors.append("CaptureEngine must persist recording URLs with absoluteString, not description")


### PR DESCRIPTION
## Summary

Wait for `AVAssetWriter` finalization and recording-history persistence before publishing the recorder's idle state.

## Baseline

This change is stacked on PR #4 (`lfg/screen-recorder-finalization-integrity-20260612`) and preserves its completed-output integrity boundary.

## Improvements

- Await movie finalization before transitioning the recorder to idle.
- Await recording-history persistence before publishing idle state.
- Return no URL for failed or absent outputs.
- Remove failed partial files.
- Persist only completed recording URLs.

## Validation

- Project and behavior source contracts.
- `make check` locally and from the repository Makefile path.
- Six focused async, await, continuation, failure, documentation, and plan mutations.
- Python checker compilation and `git diff --check`.
- All four hosted checks succeeded on the exact head.

## Risk

The hosted unsigned macOS build is required. Runtime capture validation remains permission-bound, so this evidence does not claim a successful end-to-end screen recording under macOS capture permissions.

## Follow-Ups

- Exercise finalization, failed-output cleanup, and history persistence with screen-recording permission on a macOS host when runtime capture validation is available.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
