### PR TITLE
Protect Make repository root from caller overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 PYTHON ?= python3
 XCODEBUILD ?= xcodebuild

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   recording finalization and persistence boundary.
 - See `docs/plans/2026-06-13-audio-sample-forwarding.md` for the recorded-audio
   output contract.
+- See `docs/plans/2026-06-14-make-root-override-protection.md` for the
+  caller-resistant, location-independent capture verification root.
 
 ## Contributing
 

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Make Root Override Protection
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -52,3 +52,26 @@ execution, Python 3.12 validation, mutations, and integrity screening.
 - root-declaration, checker, plan-status, README-index, and evidence mutations
 - Python syntax, workflow YAML, protected-file, secret, artifact, and
   `git diff --check` gates
+
+## Work Completed
+
+- Protected the Makefile-derived repository root from command-line and
+  environment overrides while preserving configurable Python and Xcode tools.
+- Added exact declaration, completed-evidence, and README-index contracts.
+- Preserved all Swift, recording, persistence, signing, workflow, and hosted
+  macOS build boundaries.
+
+## Verification Results
+
+- `python3 scripts/check-capture-source.py --mode project` and
+  `python3 scripts/check-capture-source.py --mode behavior` both passed.
+- From both the checkout and an external directory, all five public Make aliases passed.
+- `make ROOT=/tmp check` passed externally while still executing repository-owned
+  project and behavior contracts.
+- Python 3.12 passed the full static gate; local Xcode compilation was skipped
+  because `xcodebuild` was unavailable, leaving the hosted macOS build authoritative.
+- Six hostile mutations were rejected across root declaration, checker
+  expectation, plan status, README indexing, and recorded evidence.
+- Python syntax, workflow YAML, exact-base protected-file comparison, secret
+  screening, generated-artifact screening, and `git diff --check` passed before
+  shipping.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,54 @@
+# Make Root Override Protection
+
+## Status: Planned
+
+## Context
+
+The Makefile derives its repository root from the loaded file and uses that
+path for static capture contracts and optional local Xcode builds. GNU Make
+command-line variables outrank an ordinary assignment, so `make ROOT=/tmp
+check` can redirect those commands away from the checkout.
+
+## Requirements
+
+- **R1:** Prevent command-line and environment values from replacing the
+  Makefile-derived repository root.
+- **R2:** Keep `PYTHON` and `XCODEBUILD` configurable.
+- **R3:** Require the exact protected declaration in the capture checker.
+- **R4:** Prove every public Make alias from the checkout and an external
+  directory with a hostile `ROOT` argument.
+- **R5:** Preserve capture, audio forwarding, recording finalization,
+  persistence, signing, workflow, and macOS build contracts.
+
+## Implementation Units
+
+### U1. Protected Root
+
+Give the repository-derived root override precedence without changing recipes,
+tool selection, or the conditional local Xcode build.
+
+### U2. Capture Contract
+
+Extend `scripts/check-capture-source.py` to reject weakened, duplicate,
+displaced, or caller-controlled root declarations and incomplete evidence.
+
+### U3. Verification
+
+Run project and behavior contracts, all Make aliases, external hostile
+execution, Python 3.12 validation, mutations, and integrity screening.
+
+## Scope Boundary
+
+- Do not modify Swift, entitlements, project settings, or recording behavior.
+- Do not change hosted actions, macOS runner, Xcode build, or signing policy.
+- Do not add recordings, DerivedData, caches, or credentials.
+
+## Verification
+
+- `python3 scripts/check-capture-source.py --mode project`
+- `python3 scripts/check-capture-source.py --mode behavior`
+- `make check`
+- external `make ROOT=/tmp check`
+- root-declaration, checker, plan-status, README-index, and evidence mutations
+- Python syntax, workflow YAML, protected-file, secret, artifact, and
+  `git diff --check` gates

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -15,6 +15,7 @@ RECORDER_HANDOFF_PLAN = DOCS_PLANS / "2026-06-12-recorder-handoff-identity.md"
 RECORDING_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-12-recording-finalization-integrity.md"
 AWAITED_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-13-awaited-recording-finalization.md"
 AUDIO_FORWARDING_PLAN = DOCS_PLANS / "2026-06-13-audio-sample-forwarding.md"
+MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -64,6 +65,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-13-awaited-recording-finalization.md is missing")
     if not AUDIO_FORWARDING_PLAN.exists():
         errors.append("docs/plans/2026-06-13-audio-sample-forwarding.md is missing")
+    if not MAKE_ROOT_PLAN.exists():
+        errors.append("docs/plans/2026-06-14-make-root-override-protection.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -135,14 +138,42 @@ def project_checks():
                 errors.append(f"GitHub Actions action {action} must be pinned to a full commit SHA")
 
     makefile = MAKEFILE.read_text(encoding="utf-8") if MAKEFILE.exists() else ""
+    root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+    root_assignments = [
+        line
+        for line in makefile.splitlines()
+        if re.match(r"^(?:override\s+)?ROOT\s*[:?+]?=", line)
+    ]
+    if not makefile.startswith(f"{root_declaration}\n") or root_assignments != [
+        root_declaration
+    ]:
+        errors.append(
+            "Makefile must define exactly one protected repository-derived ROOT declaration first"
+        )
     for fragment in (
-        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        root_declaration,
         '$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode project',
         'cd "$(ROOT)" && "$(XCODEBUILD)" -project ScreenRecorder.xcodeproj',
         "CODE_SIGNING_ALLOWED=NO build",
     ):
         if fragment not in makefile:
             errors.append(f"Makefile must keep contract: {fragment}")
+
+    if MAKE_ROOT_PLAN.exists():
+        root_plan = MAKE_ROOT_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "`make ROOT=/tmp check` passed",
+            "all five public Make aliases passed",
+            "Six hostile mutations were rejected",
+            "Python 3.12",
+        ):
+            if evidence not in root_plan:
+                errors.append(
+                    f"{MAKE_ROOT_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+        if str(MAKE_ROOT_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+            errors.append(f"README.md must reference {MAKE_ROOT_PLAN.relative_to(ROOT)}")
 
     for docs_file in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         document = read_text(docs_file)


### PR DESCRIPTION
## Summary

- prevent callers from replacing the Makefile-derived capture validation root
- enforce the protected declaration, completed evidence, and README index
- preserve recording, persistence, signing, workflow, and hosted macOS build contracts

## Baseline

Command-line or environment input could replace the Makefile-derived capture validation root, allowing verification commands to resolve project files outside the checked-out repository.

## Improvements

The capture validation root is now protected from caller overrides and enforced together with completed evidence and the README index. Existing recording, persistence, signing, workflow, and hosted macOS build contracts remain within the validated boundary.

## Validation

- project and behavior source contracts
- all five Make aliases from root and externally with `ROOT=/tmp`
- Python 3.12 read-only, network-disabled static snapshot
- six isolated declaration/checker/plan/README/evidence mutations rejected
- syntax, workflow, diff, secret, artifact, and protected-path integrity gates

Local `xcodebuild` was unavailable; the unchanged macOS hosted build job remains authoritative for compilation.

## Risk

Compilation was not run locally because `xcodebuild` was unavailable. The exact-head hosted contract and macOS build jobs all succeeded, while the change remains limited to validation path integrity and its documented evidence.

## Follow-Ups

Run the build locally on a compatible macOS/Xcode host when available. Future validation changes should preserve the protected root declaration and the existing recording, persistence, and signing contracts.
