### PR TITLE
Propagate movie writer startup failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Propagated movie writer startup failures before constructing or starting the
+  ScreenCaptureKit stream.
+
 ## 2026-06-13
 
 - Added audio sample forwarding from accepted ScreenCaptureKit buffers to the

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -54,9 +54,9 @@ class CaptureEngine: NSObject, @unchecked Sendable {
             streamOutput.pcmBufferHandler = { self.powerMeter.process(buffer: $0) }
             self.movie = movie
             self.startTime = Date()
-            self.movie.startRecording(height: Int(configuration.height), width: Int(configuration.width))
 
             do {
+                try self.movie.startRecording(height: Int(configuration.height), width: Int(configuration.width))
                 stream = SCStream(filter: filter, configuration: configuration, delegate: streamOutput)
 
                 // Add a stream output to capture screen content.

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -3,6 +3,10 @@ import SwiftUI
 import Foundation
 import AVFoundation
 
+enum MovieRecorderError: Error {
+    case documentDirectoryUnavailable
+}
+
 class MovieRecorder {
 
     private var assetWriter: AVAssetWriter?
@@ -29,17 +33,15 @@ class MovieRecorder {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
     }
 
-    func startRecording(height: Int, width: Int) {
+    func startRecording(height: Int, width: Int) throws {
         // Create an asset writer that records to a temporary file
         let outputFileName = NSUUID().uuidString
         guard let outputFileURL = documentDirectory()?
             .appendingPathComponent(outputFileName)
             .appendingPathExtension("MOV") else {
-            return
+            throw MovieRecorderError.documentDirectoryUnavailable
         }
-        guard let assetWriter = try? AVAssetWriter(url: outputFileURL, fileType: .mov) else {
-            return
-        }
+        let assetWriter = try AVAssetWriter(url: outputFileURL, fileType: .mov)
 
         // Add an audio input
         // Add an audio input

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   metering and reset the visible timer.
 - Static behavior checks also require capture setup failures to cancel the
   movie writer and remove its unfinished file.
+- A writer startup failure propagates before ScreenCaptureKit starts, so the app
+  cannot advertise an active recording without a destination writer.
 - Static behavior checks require recording finalization to return only
   completed movie URLs, remove failed partial files, and skip recording-history
   persistence when no completed URL exists.
@@ -150,6 +152,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent capture verification root.
+- See `docs/plans/2026-06-14-writer-start-failure-propagation.md` for the
+  fail-closed movie-writer startup boundary.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,8 @@ Helpful reports include:
   development team, certificate, capture permission, or recording data.
 - Capture setup failures must cancel unfinished movie writers and remove their
   partial local files without saving recording metadata.
+- A writer startup failure must propagate before ScreenCaptureKit starts so no
+  writerless recording state is exposed.
 - Recording finalization persists history only after the asset writer reports
   completion; failed partial files are removed without logging their URLs.
 - Awaited recording finalization keeps stop completion and idle-state publication

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,7 @@ Priority:
 - Release retained capture streams when stop or start failure completes
 - Keep the menu bar recording timer reset after recording stops
 - Clean up audio metering and timer state when recording start fails
+- Propagate writer startup failure before ScreenCaptureKit enters capture
 - Remove unfinished movie files when capture setup fails
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs

--- a/docs/plans/2026-06-14-writer-start-failure-propagation.md
+++ b/docs/plans/2026-06-14-writer-start-failure-propagation.md
@@ -1,0 +1,38 @@
+# Writer Start Failure Propagation
+
+## Status: Planned
+
+## Context
+
+`MovieRecorder.startRecording()` silently returns when it cannot resolve the
+documents directory or create `AVAssetWriter`. `CaptureEngine.startCapture()`
+then starts ScreenCaptureKit anyway, so the UI can report an active recording
+that has no movie writer and can never produce a saved recording.
+
+## Priority
+
+High recording-state integrity. Capture must not enter a running state unless
+the destination writer was created successfully.
+
+## Requirements
+
+- Propagate output-URL and asset-writer creation failures from `MovieRecorder`.
+- Finish the capture stream with that error before constructing or starting
+  `SCStream`.
+- Preserve writer cleanup, successful recorder identity, audio/video forwarding,
+  and awaited finalization behavior.
+- Add fail-closed source contracts and mutation-sensitive coverage.
+- Keep maintained documentation and completed verification evidence aligned.
+
+## Scope Boundaries
+
+- Do not change output location, codec settings, capture permissions, Core Data,
+  timer behavior, stream configuration, or supported macOS/Xcode versions.
+
+## Verification
+
+- focused project and behavior source contracts
+- repository and external-directory `make check`
+- hostile writer-error, ordering, cleanup, documentation, and plan mutations
+- hosted unsigned macOS build on canonical push and pull-request events
+- generated-artifact, recording-file, credential-pattern, and exact-diff audits

--- a/docs/plans/2026-06-14-writer-start-failure-propagation.md
+++ b/docs/plans/2026-06-14-writer-start-failure-propagation.md
@@ -1,6 +1,6 @@
 # Writer Start Failure Propagation
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -36,3 +36,17 @@ the destination writer was created successfully.
 - hostile writer-error, ordering, cleanup, documentation, and plan mutations
 - hosted unsigned macOS build on canonical push and pull-request events
 - generated-artifact, recording-file, credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused project and behavior source contracts passed with writer startup
+  ordered before `SCStream` construction and retained failure cleanup.
+- The repository and external-directory `make check` passed; Linux truthfully
+  reported the static-only boundary because `xcodebuild` is unavailable.
+- Six hostile writer startup mutations were rejected across the throwing
+  signature, writer error propagation, startup ordering, cleanup, documentation,
+  and completed-plan status.
+- Final generated-artifact, recording-file, and credential-pattern audits passed
+  with only the intended capture, recorder, checker, documentation, and plan
+  changes.
+- Hosted unsigned macOS compilation remains required on the exact pushed head.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -16,6 +16,7 @@ RECORDING_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-12-recording-finalization-in
 AWAITED_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-13-awaited-recording-finalization.md"
 AUDIO_FORWARDING_PLAN = DOCS_PLANS / "2026-06-13-audio-sample-forwarding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
+WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-writer-start-failure-propagation.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -38,6 +39,7 @@ def require_paths():
         "CaptureSample/ContentView.swift",
         "CaptureSample/Record.swift",
         "CaptureSample/PlayerViewer.swift",
+        str(WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -185,6 +187,8 @@ def project_checks():
             errors.append(f"{docs_file} must document awaited recording finalization")
         if "audio sample forwarding" not in document.lower():
             errors.append(f"{docs_file} must document audio sample forwarding")
+        if "writer startup failure" not in document.lower():
+            errors.append(f"{docs_file} must document writer startup failure propagation")
 
     entitlements = read_text("CaptureSample/CaptureSample.entitlements")
     if "<plist version=\"1.0\">" not in entitlements:
@@ -319,6 +323,31 @@ def behavior_checks():
         errors.append("CaptureEngine must not force unwrap the recorder during handoff")
     if "streamOutput.movie = movie" not in capture_engine or "self.movie = movie" not in capture_engine:
         errors.append("CaptureEngine and stream output must share the caller-provided recorder")
+    if "enum MovieRecorderError: Error" not in record or "case documentDirectoryUnavailable" not in record:
+        errors.append("MovieRecorder must define an explicit output-directory startup error")
+    if "func startRecording(height: Int, width: Int) throws" not in record:
+        errors.append("MovieRecorder.startRecording must propagate writer startup failures")
+    if "throw MovieRecorderError.documentDirectoryUnavailable" not in record:
+        errors.append("MovieRecorder must propagate missing output-directory failures")
+    if "let assetWriter = try AVAssetWriter(url: outputFileURL, fileType: .mov)" not in record:
+        errors.append("MovieRecorder must propagate AVAssetWriter creation failures")
+    writer_start = capture_engine.find("try self.movie.startRecording(")
+    stream_start = capture_engine.find("stream = SCStream(")
+    failure_cleanup = capture_engine.find("self.movie.cancelRecording()")
+    if min(writer_start, stream_start, failure_cleanup) < 0 or not writer_start < stream_start < failure_cleanup:
+        errors.append("CaptureEngine must start the writer before SCStream and retain failure cleanup")
+    if WRITER_START_FAILURE_PLAN.exists():
+        writer_plan = WRITER_START_FAILURE_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile writer startup mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in writer_plan:
+                errors.append(
+                    f"{WRITER_START_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")
     if "Text(screenRecorder.timerString)" not in capture_app:


### PR DESCRIPTION
## Summary

- Make movie-writer startup propagate missing output-directory and `AVAssetWriter` creation failures.
- Start the writer inside the existing capture failure boundary before constructing `SCStream`.
- Preserve partial-file cleanup, recorder identity, audio/video forwarding, and awaited finalization contracts.

## Baseline

Movie-writer startup failures could be hidden before stream construction. A missing output directory or `AVAssetWriter` creation failure therefore did not reliably reach the existing capture failure boundary and cleanup path.

## Improvements

- Make `MovieRecorder.startRecording` throwing.
- Start the writer inside the existing `CaptureEngine` failure boundary before constructing `SCStream`.
- Preserve cancellation, partial-file cleanup, recorder identity, sample forwarding, and awaited finalization behavior.

## Validation

- Repository and external-directory `make check`
- Six hostile mutations covering throwing behavior, swallowed errors, startup ordering, cleanup, documentation, and plan status
- Generated-artifact, recording-file, credential-pattern, staged-diff, and whitespace audits
- Hosted unsigned macOS build required on the exact PR head

Local Linux validation truthfully uses the repository's static-only path because `xcodebuild` is unavailable.

## Risk

Interactive ScreenCaptureKit permission and recording behavior cannot be exercised in hosted CI. The exact-head contract and macOS build checks were not all terminal in the initial bounded snapshot, and PR #8 is stacked on PR #7.

## Follow-Ups

Retain the throwing-startup, ordering, and cleanup mutation coverage. Merge the stacked pull requests only with explicit authorization and in base-first order.
