### PR TITLE
fix(recording): stop capture on writer start failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-14
 
+- Propagated runtime writer start failure from the first video frame through
+  partial-file cleanup and capture-stream shutdown.
 - Propagated movie writer startup failures before constructing or starting the
   ScreenCaptureKit stream.
 

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -52,6 +52,9 @@ class CaptureEngine: NSObject, @unchecked Sendable {
             streamOutput.movie = movie
             streamOutput.capturedFrameHandler = { continuation.yield($0) }
             streamOutput.pcmBufferHandler = { self.powerMeter.process(buffer: $0) }
+            streamOutput.recordingErrorHandler = { [weak self] error in
+                self?.failCapture(error)
+            }
             self.movie = movie
             self.startTime = Date()
 
@@ -101,6 +104,17 @@ class CaptureEngine: NSObject, @unchecked Sendable {
 
     }
 
+    private func failCapture(_ error: Error) {
+        movie.cancelRecording()
+        continuation?.finish(throwing: error)
+        continuation = nil
+        let stream = self.stream
+        self.stream = nil
+        Task {
+            try? await stream?.stopCapture()
+        }
+    }
+
     /// - Tag: UpdateStreamConfiguration
     func update(configuration: SCStreamConfiguration, filter: SCContentFilter) async {
         do {
@@ -119,6 +133,7 @@ private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDeleg
 
     var pcmBufferHandler: ((AVAudioPCMBuffer) -> Void)?
     var capturedFrameHandler: ((CapturedFrame) -> Void)?
+    var recordingErrorHandler: ((Error) -> Void)?
 
     // Store the the startCapture continuation, so you can cancel it if an error occurs.
     private var continuation: AsyncThrowingStream<CapturedFrame, Error>.Continuation?
@@ -142,7 +157,11 @@ private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDeleg
             // Create a CapturedFrame structure for a video sample buffer.
             guard let frame = createFrame(for: sampleBuffer) else { return }
             capturedFrameHandler?(frame)
-            movie?.recordVideo(sampleBuffer: sampleBuffer)
+            do {
+                try movie?.recordVideo(sampleBuffer: sampleBuffer)
+            } catch {
+                recordingErrorHandler?(error)
+            }
 
         case .audio:
             // Create an AVAudioPCMBuffer from an audio sample buffer.

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -5,6 +5,7 @@ import AVFoundation
 
 enum MovieRecorderError: Error {
     case documentDirectoryUnavailable
+    case assetWriterStartFailed
 }
 
 class MovieRecorder {
@@ -115,14 +116,16 @@ class MovieRecorder {
         try? FileManager.default.removeItem(at: assetWriter.outputURL)
     }
 
-    func recordVideo(sampleBuffer: CMSampleBuffer) {
+    func recordVideo(sampleBuffer: CMSampleBuffer) throws {
         guard isRecording,
             let assetWriter = assetWriter else {
                 return
         }
 
         if assetWriter.status == .unknown {
-            assetWriter.startWriting()
+            guard assetWriter.startWriting() else {
+                throw assetWriter.error ?? MovieRecorderError.assetWriterStartFailed
+            }
             assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
         } else if assetWriter.status == .writing {
             if let input = assetWriterVideoInput,

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   movie writer and remove its unfinished file.
 - A writer startup failure propagates before ScreenCaptureKit starts, so the app
   cannot advertise an active recording without a destination writer.
+- A runtime writer start failure on the first video frame cancels partial output,
+  fails the frame stream, and stops the retained ScreenCaptureKit stream.
 - Static behavior checks require recording finalization to return only
   completed movie URLs, remove failed partial files, and skip recording-history
   persistence when no completed URL exists.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,8 @@ Helpful reports include:
   partial local files without saving recording metadata.
 - A writer startup failure must propagate before ScreenCaptureKit starts so no
   writerless recording state is exposed.
+- A runtime writer start failure must cancel partial output and stop the active
+  capture stream instead of leaving a writerless recording running.
 - Recording finalization persists history only after the asset writer reports
   completion; failed partial files are removed without logging their URLs.
 - Awaited recording finalization keeps stop completion and idle-state publication

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
 - Keep the menu bar recording timer reset after recording stops
 - Clean up audio metering and timer state when recording start fails
 - Propagate writer startup failure before ScreenCaptureKit enters capture
+- Stop active capture when a runtime writer start failure rejects the first frame
 - Remove unfinished movie files when capture setup fails
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs

--- a/docs/plans/2026-06-14-runtime-writer-start-failure.md
+++ b/docs/plans/2026-06-14-runtime-writer-start-failure.md
@@ -1,6 +1,6 @@
 # Runtime Writer Start Failure
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -47,6 +47,20 @@ the active capture path instead of presenting a recording that cannot finalize.
   mutations
 - hosted unsigned macOS build on the exact pull-request head
 - generated-artifact, recording-file, credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused behavior source contracts passed with the writer Boolean result,
+  fallback error, error forwarding, cleanup ordering, and asynchronous stream
+  shutdown retained.
+- The repository and external-directory `make check` passed; Linux truthfully
+  reported the static-only boundary because `xcodebuild` is unavailable.
+- Six hostile runtime writer mutations were rejected across result checking,
+  thrown error, forwarding, cleanup, documentation, and completed-plan status.
+- Final generated-artifact, recording-file, and credential-pattern audits passed
+  with only the intended recorder, capture engine, checker, documentation, and
+  plan changes.
+- Hosted unsigned macOS compilation remains required on the exact pushed head.
 
 ## Risks
 

--- a/docs/plans/2026-06-14-runtime-writer-start-failure.md
+++ b/docs/plans/2026-06-14-runtime-writer-start-failure.md
@@ -1,0 +1,56 @@
+# Runtime Writer Start Failure
+
+## Status: Planned
+
+## Context
+
+`MovieRecorder.startRecording()` now propagates output URL and writer creation
+errors before ScreenCaptureKit starts. The first video frame still calls
+`AVAssetWriter.startWriting()` without checking its Boolean result, so a runtime
+writer failure can leave capture running even though no movie can be produced.
+
+## Priority
+
+High recording-state integrity. A failed asset-writer transition must terminate
+the active capture path instead of presenting a recording that cannot finalize.
+
+## Requirements
+
+- Throw the asset writer's runtime error when `startWriting()` returns `false`,
+  with an explicit fallback error when AVFoundation supplies none.
+- Forward that error from the screen sample handler to the capture engine.
+- Cancel partial movie output, finish the frame stream with the error, and stop
+  the retained ScreenCaptureKit stream.
+- Preserve successful video/audio forwarding, awaited finalization, and existing
+  writer-construction failure behavior.
+- Add fail-closed source contracts and keep maintained documentation and
+  completed verification evidence aligned.
+
+## Scope Boundaries
+
+- Do not change output location, codec settings, capture permissions, Core Data,
+  timer behavior, stream configuration, or supported macOS/Xcode versions.
+
+## Implementation Units
+
+1. Make first-frame writer startup failure a throwing `MovieRecorder` boundary.
+2. Route recorder errors through `CaptureEngineStreamOutput` to centralized
+   capture cleanup and asynchronous stream shutdown.
+3. Extend source contracts and maintained documentation for the runtime failure
+   path and completed validation evidence.
+
+## Verification
+
+- focused source and ordering contracts
+- repository and external-directory `make check`
+- hostile writer-result, error-forwarding, cleanup, documentation, and plan
+  mutations
+- hosted unsigned macOS build on the exact pull-request head
+- generated-artifact, recording-file, credential-pattern, and exact-diff audits
+
+## Risks
+
+- Linux validation is static-only; Swift concurrency and ScreenCaptureKit API
+  compatibility require the hosted macOS/Xcode build.
+- Runtime permission, device, and AVFoundation failure behavior still requires a
+  permission-capable macOS environment for end-to-end validation.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -17,6 +17,7 @@ AWAITED_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-13-awaited-recording-finalizat
 AUDIO_FORWARDING_PLAN = DOCS_PLANS / "2026-06-13-audio-sample-forwarding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-writer-start-failure-propagation.md"
+RUNTIME_WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-runtime-writer-start-failure.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -40,6 +41,7 @@ def require_paths():
         "CaptureSample/Record.swift",
         "CaptureSample/PlayerViewer.swift",
         str(WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
+        str(RUNTIME_WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -189,6 +191,8 @@ def project_checks():
             errors.append(f"{docs_file} must document audio sample forwarding")
         if "writer startup failure" not in document.lower():
             errors.append(f"{docs_file} must document writer startup failure propagation")
+        if "runtime writer start failure" not in document.lower():
+            errors.append(f"{docs_file} must document runtime writer start failure containment")
 
     entitlements = read_text("CaptureSample/CaptureSample.entitlements")
     if "<plist version=\"1.0\">" not in entitlements:
@@ -331,6 +335,27 @@ def behavior_checks():
         errors.append("MovieRecorder must propagate missing output-directory failures")
     if "let assetWriter = try AVAssetWriter(url: outputFileURL, fileType: .mov)" not in record:
         errors.append("MovieRecorder must propagate AVAssetWriter creation failures")
+    for fragment in (
+        "case assetWriterStartFailed",
+        "func recordVideo(sampleBuffer: CMSampleBuffer) throws",
+        "guard assetWriter.startWriting() else {",
+        "throw assetWriter.error ?? MovieRecorderError.assetWriterStartFailed",
+    ):
+        if fragment not in record:
+            errors.append(f"MovieRecorder must propagate runtime writer start failures via {fragment!r}")
+    for fragment in (
+        "streamOutput.recordingErrorHandler = { [weak self] error in",
+        "self?.failCapture(error)",
+        "private func failCapture(_ error: Error)",
+        "movie.cancelRecording()\n        continuation?.finish(throwing: error)",
+        "let stream = self.stream\n        self.stream = nil",
+        "try? await stream?.stopCapture()",
+        "var recordingErrorHandler: ((Error) -> Void)?",
+        "try movie?.recordVideo(sampleBuffer: sampleBuffer)",
+        "recordingErrorHandler?(error)",
+    ):
+        if fragment not in capture_engine:
+            errors.append(f"CaptureEngine must contain runtime writer failure via {fragment!r}")
     writer_start = capture_engine.find("try self.movie.startRecording(")
     stream_start = capture_engine.find("stream = SCStream(")
     failure_cleanup = capture_engine.find("self.movie.cancelRecording()")
@@ -347,6 +372,18 @@ def behavior_checks():
             if evidence not in writer_plan:
                 errors.append(
                     f"{WRITER_START_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+    if RUNTIME_WRITER_START_FAILURE_PLAN.exists():
+        runtime_writer_plan = RUNTIME_WRITER_START_FAILURE_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile runtime writer mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in runtime_writer_plan:
+                errors.append(
+                    f"{RUNTIME_WRITER_START_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")


### PR DESCRIPTION
## Summary

A first-frame `AVAssetWriter.startWriting()` failure now terminates recording instead of leaving ScreenCaptureKit running without a viable movie. The runtime error is forwarded through the frame stream, partial output is cancelled, and the retained capture stream is stopped and released.

## Baseline

Writer output URL and construction failures already propagated before ScreenCaptureKit startup. The later Boolean failure from `startWriting()` was ignored, allowing the UI and capture stream to continue even though finalization could never produce a recording.

## Improvements

- Throw the asset writer's runtime error, with an explicit fallback when AVFoundation supplies none.
- Forward first-frame recording errors from `CaptureEngineStreamOutput` to centralized capture cleanup.
- Cancel partial output and fail the frame continuation before asynchronously stopping and releasing `SCStream`.
- Preserve successful video/audio forwarding, writer construction, and awaited finalization behavior.
- Add fail-closed source contracts and completed maintenance evidence.

## Validation

- Repository and external-directory `make check` passed project and behavior contracts.
- Six hostile writer-result, fallback-error, forwarding, cleanup, documentation, and completed-plan mutations were rejected.
- Exact diff, whitespace, generated-artifact, recording-file, and secret-addition audits passed.
- Browser validation is not applicable to this native macOS capture path.
- Linux does not provide `xcodebuild`; the hosted unsigned macOS build is the required Swift API/compiler validation.

## Risk

The change affects first-frame failure cleanup only. ScreenCaptureKit permissions, device behavior, AVFoundation runtime failures, and capture shutdown timing still require a permission-capable macOS environment for end-to-end validation.

## Follow-Ups

This PR is stacked on PR #8 and should remain open until its base is integrated or explicitly retargeted. Broader synchronization between concurrent audio/video sample queues remains outside this change.

## Post-Deploy Monitoring & Validation

No automated production deployment exists for this sample. On the first maintainer-owned permission-capable macOS run after integration, force or observe a writer startup failure and confirm the recording indicator clears, no partial movie remains, and capture stops; a persistent recording indicator, retained capture stream, or partial file is the rollback trigger. Validation window: the first macOS smoke test after integration; owner: repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
