### PR TITLE
Propagate video sample append failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Propagated video sample append failure through partial-file cleanup and
+  capture-stream shutdown.
+
 ## 2026-06-14
 
 - Propagated runtime writer start failure from the first video frame through

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -6,6 +6,7 @@ import AVFoundation
 enum MovieRecorderError: Error {
     case documentDirectoryUnavailable
     case assetWriterStartFailed
+    case assetWriterAppendFailed
 }
 
 class MovieRecorder {
@@ -130,7 +131,9 @@ class MovieRecorder {
         } else if assetWriter.status == .writing {
             if let input = assetWriterVideoInput,
                 input.isReadyForMoreMediaData {
-                input.append(sampleBuffer)
+                guard input.append(sampleBuffer) else {
+                    throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   cannot advertise an active recording without a destination writer.
 - A runtime writer start failure on the first video frame cancels partial output,
   fails the frame stream, and stops the retained ScreenCaptureKit stream.
+- A video sample append failure follows the same cleanup path instead of
+  allowing capture to continue with a failed movie writer.
 - Static behavior checks require recording finalization to return only
   completed movie URLs, remove failed partial files, and skip recording-history
   persistence when no completed URL exists.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ Helpful reports include:
   writerless recording state is exposed.
 - A runtime writer start failure must cancel partial output and stop the active
   capture stream instead of leaving a writerless recording running.
+- A video sample append failure must propagate through the same cleanup boundary
+  instead of allowing capture to continue after the writer rejects a frame.
 - Recording finalization persists history only after the asset writer reports
   completion; failed partial files are removed without logging their URLs.
 - Awaited recording finalization keeps stop completion and idle-state publication

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Clean up audio metering and timer state when recording start fails
 - Propagate writer startup failure before ScreenCaptureKit enters capture
 - Stop active capture when a runtime writer start failure rejects the first frame
+- Propagate video sample append failure through the existing recording cleanup path
 - Remove unfinished movie files when capture setup fails
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs

--- a/docs/plans/2026-06-15-video-append-failure-propagation.md
+++ b/docs/plans/2026-06-15-video-append-failure-propagation.md
@@ -1,0 +1,52 @@
+# Video Append Failure Propagation
+
+## Status: In Progress
+
+## Context
+
+`MovieRecorder.recordVideo()` propagates `AVAssetWriter.startWriting()` failure,
+but it ignores the Boolean result of `AVAssetWriterInput.append(_:)`. A writer
+that stops accepting video samples can therefore leave capture running until a
+later stop, producing an incomplete or failed recording without using the
+existing recording-error cleanup path.
+
+## Priority
+
+High recording-integrity resilience. A rejected video sample should fail the
+capture immediately and remove the partial movie through the established
+runtime writer failure boundary.
+
+## Requirements
+
+- Treat a `false` video input append result as a recording failure.
+- Prefer the writer's concrete error and provide a stable fallback error.
+- Propagate the error through `recordVideo()` to the existing
+  `recordingErrorHandler` and `failCapture(_:)` cleanup path.
+- Preserve readiness checks, audio forwarding, writer startup, finalization,
+  persistence, and cancellation semantics.
+- Add fail-closed static and mutation-sensitive contracts.
+
+## Scope Boundaries
+
+- Do not change audio append behavior, capture configuration, project settings,
+  dependencies, persistence schema, or UI behavior.
+- Do not claim permission-capable runtime recording validation from Linux or
+  unsigned hosted builds.
+- Do not merge or close stacked pull requests without explicit authorization.
+
+## Implementation Units
+
+1. Add a fallback append-failure error and throw when the ready video input
+   rejects a sample.
+2. Extend the source checker to protect append-result handling and the existing
+   error handoff.
+3. Update maintained documentation and completed verification evidence.
+
+## Verification
+
+- focused source-contract validation
+- repository and external-directory `make check`
+- hostile append-result, fallback-error, error-handoff, documentation, and
+  completed-plan mutations
+- workflow YAML, plist, scheme XML, Python artifact, recording artifact,
+  credential-pattern, and exact-diff audits

--- a/docs/plans/2026-06-15-video-append-failure-propagation.md
+++ b/docs/plans/2026-06-15-video-append-failure-propagation.md
@@ -1,6 +1,6 @@
 # Video Append Failure Propagation
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -50,3 +50,22 @@ runtime writer failure boundary.
   completed-plan mutations
 - workflow YAML, plist, scheme XML, Python artifact, recording artifact,
   credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused behavior and project source-contract validation passed.
+- The repository and external-directory `make check` passed; Linux truthfully
+  used the documented static-only path because `xcodebuild` is unavailable.
+- Six hostile video append mutations were rejected across fallback error,
+  append-result handling, error handoff, documentation, plan status, and
+  completed evidence.
+- The generated-artifact, recording-file, and credential-pattern audits passed,
+  along with workflow YAML, entitlements plist, shared scheme XML,
+  conflict-marker, and exact-diff checks.
+
+## Remaining Risks
+
+- Permission-capable ScreenCaptureKit and AVAssetWriter append failure behavior
+  still requires end-to-end macOS runtime validation.
+- Hosted unsigned compilation proves source compatibility but does not grant
+  screen-recording permission or exercise a live movie writer failure.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -18,6 +18,7 @@ AUDIO_FORWARDING_PLAN = DOCS_PLANS / "2026-06-13-audio-sample-forwarding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-writer-start-failure-propagation.md"
 RUNTIME_WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-runtime-writer-start-failure.md"
+VIDEO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-video-append-failure-propagation.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -42,6 +43,7 @@ def require_paths():
         "CaptureSample/PlayerViewer.swift",
         str(WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
         str(RUNTIME_WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
+        str(VIDEO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -193,6 +195,8 @@ def project_checks():
             errors.append(f"{docs_file} must document writer startup failure propagation")
         if "runtime writer start failure" not in document.lower():
             errors.append(f"{docs_file} must document runtime writer start failure containment")
+        if "video sample append failure" not in document.lower():
+            errors.append(f"{docs_file} must document video sample append failure propagation")
 
     entitlements = read_text("CaptureSample/CaptureSample.entitlements")
     if "<plist version=\"1.0\">" not in entitlements:
@@ -344,6 +348,13 @@ def behavior_checks():
         if fragment not in record:
             errors.append(f"MovieRecorder must propagate runtime writer start failures via {fragment!r}")
     for fragment in (
+        "case assetWriterAppendFailed",
+        "guard input.append(sampleBuffer) else {",
+        "throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed",
+    ):
+        if fragment not in record:
+            errors.append(f"MovieRecorder must propagate video sample append failures via {fragment!r}")
+    for fragment in (
         "streamOutput.recordingErrorHandler = { [weak self] error in",
         "self?.failCapture(error)",
         "private func failCapture(_ error: Error)",
@@ -384,6 +395,18 @@ def behavior_checks():
             if evidence not in runtime_writer_plan:
                 errors.append(
                     f"{RUNTIME_WRITER_START_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+    if VIDEO_APPEND_FAILURE_PLAN.exists():
+        append_failure_plan = VIDEO_APPEND_FAILURE_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile video append mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in append_failure_plan:
+                errors.append(
+                    f"{VIDEO_APPEND_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")


### PR DESCRIPTION
## Summary

Propagate rejected video sample appends through the existing movie-writer failure cleanup path instead of allowing capture to continue with a failed writer.

## Baseline

PR #9 handles `AVAssetWriter.startWriting()` failure, but `MovieRecorder.recordVideo()` ignored the Boolean result of `AVAssetWriterInput.append(_:)` after the writer entered its writing state.

## Improvements

- Add a stable fallback append-failure error.
- Throw when a ready video input rejects a sample, preferring the writer's concrete error.
- Reuse the existing `recordingErrorHandler` and `failCapture(_:)` path to cancel partial output and stop the retained stream.
- Add fail-closed source, documentation, and completed-plan contracts.

## Validation

- Repository and external-directory `make check` passed project and behavior contracts.
- Six focused hostile append-result, fallback-error, handoff, documentation, and plan mutations were rejected.
- Workflow YAML, entitlements plist, shared scheme XML, generated-artifact, recording-file, credential, conflict-marker, and exact-diff audits passed.
- Local Linux validation truthfully remained static-only because `xcodebuild` is unavailable.

## Risk

Permission-capable ScreenCaptureKit and AVAssetWriter append failure behavior still require end-to-end macOS runtime validation. Hosted unsigned compilation verifies source compatibility but cannot exercise a live recording failure.

## Follow-Ups

This PR is stacked on PR #9 and should retain base-first ordering. Do not merge or close either PR without explicit owner authorization.
