### PR TITLE
Propagate audio sample append failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ built with ScreenCaptureKit.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-screen-recorder-macos-baseline.md` for the canonical capture and recording safety baseline.
+- Video and audio sample append failures propagate through the shared recording cleanup path.
 - See `docs/plans/2026-06-08-local-player-viewer.md` for the local player viewer guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-15
 
+- Video and audio sample append failures propagate through the shared recording cleanup path.
 - Propagated video sample append failure through partial-file cleanup and
   capture-stream shutdown.
 

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -167,7 +167,11 @@ private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDeleg
             // Create an AVAudioPCMBuffer from an audio sample buffer.
             guard let samples = createPCMBuffer(for: sampleBuffer) else { return }
             pcmBufferHandler?(samples)
-            movie?.recordAudio(sampleBuffer: sampleBuffer)
+            do {
+                try movie?.recordAudio(sampleBuffer: sampleBuffer)
+            } catch {
+                recordingErrorHandler?(error)
+            }
         @unknown default:
             logger.error("Ignoring unknown stream output type from ScreenCaptureKit")
         }

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -138,7 +138,7 @@ class MovieRecorder {
         }
     }
 
-    func recordAudio(sampleBuffer: CMSampleBuffer) {
+    func recordAudio(sampleBuffer: CMSampleBuffer) throws {
         guard isRecording,
             let assetWriter = assetWriter,
             assetWriter.status == .writing,
@@ -147,6 +147,8 @@ class MovieRecorder {
                 return
         }
 
-        input.append(sampleBuffer)
+        guard input.append(sampleBuffer) else {
+            throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   fails the frame stream, and stops the retained ScreenCaptureKit stream.
 - A video sample append failure follows the same cleanup path instead of
   allowing capture to continue with a failed movie writer.
+- Video and audio sample append failures propagate through the shared recording cleanup path.
 - Static behavior checks require recording finalization to return only
   completed movie URLs, remove failed partial files, and skip recording-history
   persistence when no completed URL exists.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,7 @@ Helpful reports include:
   capture stream instead of leaving a writerless recording running.
 - A video sample append failure must propagate through the same cleanup boundary
   instead of allowing capture to continue after the writer rejects a frame.
+- Video and audio sample append failures propagate through the shared recording cleanup path.
 - Recording finalization persists history only after the asset writer reports
   completion; failed partial files are removed without logging their URLs.
 - Awaited recording finalization keeps stop completion and idle-state publication

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Propagate writer startup failure before ScreenCaptureKit enters capture
 - Stop active capture when a runtime writer start failure rejects the first frame
 - Propagate video sample append failure through the existing recording cleanup path
+- Video and audio sample append failures propagate through the shared recording cleanup path.
 - Remove unfinished movie files when capture setup fails
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs

--- a/docs/plans/2026-06-15-audio-append-failure-propagation.md
+++ b/docs/plans/2026-06-15-audio-append-failure-propagation.md
@@ -1,0 +1,78 @@
+# Audio Append Failure Propagation
+
+Status: Planned
+
+## Problem
+
+Video sample appends now propagate `AVAssetWriterInput.append` failures through
+the capture error handler, but audio appends still discard the boolean result.
+An audio writer failure can therefore leave capture appearing healthy while
+the output movie is no longer being written reliably.
+
+## Requirements
+
+1. Make `recordAudio` propagate failed sample appends.
+2. Use the asset writer error when available and the existing append fallback
+   otherwise.
+3. Route audio recording errors through `recordingErrorHandler` just like video
+   recording errors.
+4. Preserve audio metering, sample conversion, readiness/backpressure guards,
+   writer startup ownership, video behavior, stop/finalization, and UI state.
+5. Add mutation-sensitive static contracts and truthful verification evidence.
+
+## Implementation Units
+
+### 1. Propagate audio append failure
+
+Files:
+
+- `CaptureSample/Record.swift`
+- `CaptureSample/CaptureEngine.swift`
+
+Make the audio recorder method throwing, guard the append result, and catch the
+error at the ScreenCaptureKit audio callback boundary.
+
+### 2. Protect parity with video
+
+Files:
+
+- `scripts/check-capture-source.py`
+- `docs/plans/2026-06-15-audio-append-failure-propagation.md`
+
+Require audio append failure propagation, error-handler routing, method-scoped
+ordering, documentation, and completed-plan evidence without weakening video
+contracts.
+
+### 3. Document writer integrity
+
+Files:
+
+- `AGENTS.md`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+
+Record that failed video or audio sample appends terminate capture through the
+shared recording error path.
+
+## Verification Plan
+
+- Run `make check` from the repository and an external directory with explicit
+  timeouts.
+- Reject isolated mutations for throwing signature, append result, writer
+  error, fallback error, callback catch, guidance, and completed plan.
+- Audit the exact diff, generated artifacts, changed-line secrets, staged
+  paths, and whitespace before commit.
+- Take one bounded exact-head hosted macOS snapshot after push; do not claim
+  local Xcode compilation on Linux.
+
+## Scope Boundaries
+
+- Do not change writer configuration, sample formats, readiness guards,
+  backpressure behavior, metering, capture selection, timers, persistence, or
+  finalization.
+- Do not add retries or silently drop failed writer appends.
+- Do not claim local Xcode, ScreenCaptureKit, audio-device, or movie playback
+  execution on Linux.
+- Do not merge or close any pull request without explicit authorization.

--- a/docs/plans/2026-06-15-audio-append-failure-propagation.md
+++ b/docs/plans/2026-06-15-audio-append-failure-propagation.md
@@ -1,6 +1,6 @@
 # Audio Append Failure Propagation
 
-Status: Planned
+Status: Completed
 
 ## Problem
 
@@ -56,16 +56,17 @@ Files:
 Record that failed video or audio sample appends terminate capture through the
 shared recording error path.
 
-## Verification Plan
+## Verification Completed
 
-- Run `make check` from the repository and an external directory with explicit
-  timeouts.
-- Reject isolated mutations for throwing signature, append result, writer
-  error, fallback error, callback catch, guidance, and completed plan.
-- Audit the exact diff, generated artifacts, changed-line secrets, staged
-  paths, and whitespace before commit.
-- Take one bounded exact-head hosted macOS snapshot after push; do not claim
-  local Xcode compilation on Linux.
+- repository and external-directory `make check` passed with project and
+  behavior contracts; Linux truthfully skipped unavailable `xcodebuild`.
+- Eight hostile audio append mutations were rejected for the throwing
+  signature, append result, writer error, fallback error, callback try/catch,
+  guidance, and completed-plan boundaries.
+- hostile audio append mutations were rejected.
+- generated-artifact, recording-file, and credential-pattern audits passed.
+- Hosted macOS compilation will be captured in one bounded exact-head snapshot
+  after push without polling.
 
 ## Scope Boundaries
 

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -19,6 +19,7 @@ MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-writer-start-failure-propagation.md"
 RUNTIME_WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-runtime-writer-start-failure.md"
 VIDEO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-video-append-failure-propagation.md"
+AUDIO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-audio-append-failure-propagation.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -44,6 +45,7 @@ def require_paths():
         str(WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
         str(RUNTIME_WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
         str(VIDEO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
+        str(AUDIO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -197,6 +199,9 @@ def project_checks():
             errors.append(f"{docs_file} must document runtime writer start failure containment")
         if "video sample append failure" not in document.lower():
             errors.append(f"{docs_file} must document video sample append failure propagation")
+    for docs_file in ("AGENTS.md", "README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
+        if "Video and audio sample append failures propagate through the shared recording cleanup path." not in read_text(docs_file):
+            errors.append(f"{docs_file} must document shared video/audio append failure cleanup")
 
     entitlements = read_text("CaptureSample/CaptureSample.entitlements")
     if "<plist version=\"1.0\">" not in entitlements:
@@ -243,13 +248,16 @@ def behavior_checks():
         required_audio_flow = (
             "guard let samples = createPCMBuffer(for: sampleBuffer) else { return }",
             "pcmBufferHandler?(samples)",
-            "movie?.recordAudio(sampleBuffer: sampleBuffer)",
+            "try movie?.recordAudio(sampleBuffer: sampleBuffer)",
+            "recordingErrorHandler?(error)",
         )
         positions = [audio_body.find(fragment) for fragment in required_audio_flow]
         if any(position < 0 for position in positions) or positions != sorted(positions):
             errors.append("CaptureEngine audio output must convert, meter, and forward the accepted sample in order")
-        if audio_body.count("movie?.recordAudio(sampleBuffer: sampleBuffer)") != 1:
+        if audio_body.count("try movie?.recordAudio(sampleBuffer: sampleBuffer)") != 1:
             errors.append("CaptureEngine audio output must forward each accepted sample exactly once")
+        if "do {" not in audio_body or "} catch {" not in audio_body:
+            errors.append("CaptureEngine audio output must route recorder failures through the shared handler")
     for key in ("X", "Y", "Width", "Height"):
         if f'contentRectValues["{key}"]' not in capture_engine:
             errors.append(f"CaptureEngine must validate the content rectangle {key} value")
@@ -354,6 +362,21 @@ def behavior_checks():
     ):
         if fragment not in record:
             errors.append(f"MovieRecorder must propagate video sample append failures via {fragment!r}")
+    audio_record = re.search(
+        r"func recordAudio\(sampleBuffer: CMSampleBuffer\) throws \{(.*?)\n    \}",
+        record,
+        re.DOTALL,
+    )
+    if not audio_record:
+        errors.append("MovieRecorder.recordAudio must remain a throwing method")
+    else:
+        audio_record_body = audio_record.group(1)
+        for fragment in (
+            "guard input.append(sampleBuffer) else {",
+            "throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed",
+        ):
+            if fragment not in audio_record_body:
+                errors.append(f"MovieRecorder.recordAudio must propagate append failure via {fragment!r}")
     for fragment in (
         "streamOutput.recordingErrorHandler = { [weak self] error in",
         "self?.failCapture(error)",
@@ -407,6 +430,18 @@ def behavior_checks():
             if evidence not in append_failure_plan:
                 errors.append(
                     f"{VIDEO_APPEND_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+    if AUDIO_APPEND_FAILURE_PLAN.exists():
+        audio_append_plan = AUDIO_APPEND_FAILURE_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile audio append mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in audio_append_plan:
+                errors.append(
+                    f"{AUDIO_APPEND_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")


### PR DESCRIPTION
## Summary

Propagate failed audio sample appends through the existing recording error and cleanup path.

## Baseline

Video append failures were handled, but `recordAudio` discarded `AVAssetWriterInput.append` failures and allowed capture to appear healthy.

## Improvements

- Make `recordAudio` throwing and reject failed writer appends.
- Use the asset writer error when available with the existing append fallback.
- Route audio writer failures through `recordingErrorHandler` while preserving metering and readiness guards.

## Validation

- Repository and external-directory `make check` passed project and behavior contracts.
- Linux truthfully skipped unavailable `xcodebuild`.
- Eight isolated hostile mutations were rejected after tightening the checker to scope audio assertions to `recordAudio`.
- Exact diff, generated artifact, recording file, credential, staged-path, and whitespace audits passed.

## Risk

No local Xcode build, ScreenCaptureKit session, audio device, writer failure, or movie playback was exercised. This PR is stacked on open PR #10.

## Follow-Ups

Exercise audio writer failure and final movie playback on the exact merged commit in a permitted macOS environment.
