### PR TITLE
fix(recording): remove ignored settings parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ built with ScreenCaptureKit.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-screen-recorder-macos-baseline.md` for the canonical capture and recording safety baseline.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- MovieRecorder exposes only its video transform at initialization; fixed audio
+  and video output settings remain inside startRecording.
 - See `docs/plans/2026-06-08-local-player-viewer.md` for the local player viewer guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- MovieRecorder exposes only its video transform at initialization; fixed audio
+  and video output settings remain inside startRecording.
+
 ## 2026-06-15
 
 - Video and audio sample append failures propagate through the shared recording cleanup path.

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -26,7 +26,7 @@ struct CapturedFrame {
 class CaptureEngine: NSObject, @unchecked Sendable {
     
     private let logger = Logger()
-    var movie: MovieRecorder = MovieRecorder(audioSettings: [:], videoSettings: [:], videoTransform: .identity)
+    var movie: MovieRecorder = MovieRecorder(videoTransform: .identity)
 
 
 

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -17,17 +17,11 @@ class MovieRecorder {
 
     private var assetWriterAudioInput: AVAssetWriterInput?
 
-    private var videoTransform: CGAffineTransform
-
-    private var videoSettings: [String: Any]
-
-    private var audioSettings: [String: Any]
+    private let videoTransform: CGAffineTransform
 
     private(set) var isRecording = false
 
-    init(audioSettings: [String: Any], videoSettings: [String: Any], videoTransform: CGAffineTransform) {
-        self.audioSettings = audioSettings
-        self.videoSettings = videoSettings
+    init(videoTransform: CGAffineTransform) {
         self.videoTransform = videoTransform
     }
 

--- a/CaptureSample/ScreenRecorder.swift
+++ b/CaptureSample/ScreenRecorder.swift
@@ -28,7 +28,7 @@ class ScreenRecorder: ObservableObject {
     }
     
     private let logger = Logger()
-    private let movie = MovieRecorder(audioSettings: [:], videoSettings: [:], videoTransform: .identity)
+    private let movie = MovieRecorder(videoTransform: .identity)
 
 
     @Published var isTimerRunning = false

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ built with ScreenCaptureKit.
 
 This README is based on the checked-in source, manifests, scripts, and repository metadata on the `main` branch. The project language mix found during review was: Swift (16).
 
+MovieRecorder exposes only its video transform at initialization; fixed audio
+and video output settings remain inside startRecording.
+
 ## Repository Contents
 
 - `README.md` - project overview and local usage notes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,9 @@
 
 The supported security scope for `ScreenRecorderMacOS` is the current default branch, `main`. Older commits, tags, branches, forks, demos, and generated artifacts are not actively supported unless the repository explicitly marks them as maintained.
 
+MovieRecorder exposes only its video transform at initialization; fixed audio
+and video output settings remain inside startRecording.
+
 Project summary: Screen Recording for MacOS
 
 ## Reporting a Vulnerability

--- a/VISION.md
+++ b/VISION.md
@@ -15,6 +15,8 @@ The current focus is:
 
 Priority:
 
+- MovieRecorder exposes only its video transform at initialization; fixed audio
+  and video output settings remain inside startRecording.
 - Preserve the ScreenCaptureKit display/window capture flow
 - Keep recording permission checks visible
 - Store recordings and metadata in documented local locations

--- a/docs/plans/2026-06-16-recorder-settings-contract.md
+++ b/docs/plans/2026-06-16-recorder-settings-contract.md
@@ -1,0 +1,82 @@
+# Recorder Settings Contract
+
+Status: In Progress
+
+## Problem
+
+`MovieRecorder` accepts and stores caller-supplied audio and video settings,
+but `startRecording` shadows both properties with fixed local dictionaries.
+The initializer therefore advertises configuration that is silently ignored,
+while both production call sites pass empty dictionaries that could not be used
+as valid writer output settings.
+
+## Requirements
+
+1. Remove the ignored audio and video settings parameters and stored properties
+   from `MovieRecorder`.
+2. Keep the existing video transform as the recorder's only initializer input.
+3. Update every production call site to use the truthful initializer contract.
+4. Preserve the exact fixed PCM audio and H.264 video writer settings,
+   recording lifecycle, writer failure propagation, append behavior,
+   finalization, persistence, and UI state.
+5. Add mutation-sensitive static contracts, synchronized guidance, and
+   truthful completion evidence.
+
+## Implementation Units
+
+### 1. Remove the misleading configuration surface
+
+Files:
+
+- `CaptureSample/Record.swift`
+- `CaptureSample/CaptureEngine.swift`
+- `CaptureSample/ScreenRecorder.swift`
+
+Delete the unused settings state and parameters, retain
+`init(videoTransform:)`, and migrate both callers without changing the fixed
+writer dictionaries inside `startRecording`.
+
+### 2. Protect the initializer and writer settings
+
+Files:
+
+- `scripts/check-capture-source.py`
+- `docs/plans/2026-06-16-recorder-settings-contract.md`
+
+Require the truthful initializer, exact call-site set, absence of the ignored
+configuration surface, retained codec fragments, guidance, and completed-plan
+evidence.
+
+### 3. Document the fixed-format contract
+
+Files:
+
+- `AGENTS.md`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+
+Record that recorder output settings are fixed inside `startRecording` rather
+than accepted and silently ignored at initialization.
+
+## Verification Plan
+
+- Capture the pre-change source evidence for the unused properties, shadowing
+  local dictionaries, and empty-dictionary call sites.
+- Run repository and external-directory `make check`.
+- Reject hostile initializer, call-site, codec, guidance, and plan-status
+  mutations.
+- Audit the exact diff, Swift conflict markers, recording artifacts, generated
+  files, modes, whitespace, and credential patterns before shipping.
+- Capture one bounded exact-head hosted snapshot after push without polling.
+
+## Scope Boundaries
+
+- Do not make output settings configurable or change their current values.
+- Do not change capture permissions, writer startup, sample timing,
+  backpressure, append failure handling, stop/finalization, persistence, or UI.
+- Do not claim local Xcode, ScreenCaptureKit, audio-device, or movie playback
+  execution on Linux.
+- PR #12 will be stacked on open PR #11; neither pull request may be merged or
+  closed without explicit authorization.

--- a/docs/plans/2026-06-16-recorder-settings-contract.md
+++ b/docs/plans/2026-06-16-recorder-settings-contract.md
@@ -1,6 +1,6 @@
 # Recorder Settings Contract
 
-Status: In Progress
+Status: Completed
 
 ## Problem
 
@@ -80,3 +80,14 @@ than accepted and silently ignored at initialization.
   execution on Linux.
 - PR #12 will be stacked on open PR #11; neither pull request may be merged or
   closed without explicit authorization.
+
+## Verification Completed
+
+- The pre-change source inspection found ignored audio/video settings
+  properties, shadowing local dictionaries, and two empty-dictionary call sites.
+- repository and external-directory `make check` passed with project and
+  behavior contracts; Linux truthfully skipped unavailable `xcodebuild`.
+- hostile recorder settings mutations were rejected.
+- generated-artifact, recording-file, and credential-pattern audits passed.
+- No local Xcode build, ScreenCaptureKit capture, audio device, movie playback,
+  credentials, or deployment was exercised.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -20,6 +20,7 @@ WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-writer-start-failure-propag
 RUNTIME_WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-runtime-writer-start-failure.md"
 VIDEO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-video-append-failure-propagation.md"
 AUDIO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-audio-append-failure-propagation.md"
+RECORDER_SETTINGS_PLAN = DOCS_PLANS / "2026-06-16-recorder-settings-contract.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -46,6 +47,7 @@ def require_paths():
         str(RUNTIME_WRITER_START_FAILURE_PLAN.relative_to(ROOT)),
         str(VIDEO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
         str(AUDIO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
+        str(RECORDER_SETTINGS_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -202,6 +204,14 @@ def project_checks():
     for docs_file in ("AGENTS.md", "README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         if "Video and audio sample append failures propagate through the shared recording cleanup path." not in read_text(docs_file):
             errors.append(f"{docs_file} must document shared video/audio append failure cleanup")
+        document = " ".join(read_text(docs_file).split())
+        if (
+            "MovieRecorder" not in document
+            or "video transform" not in document
+            or "fixed audio and video output settings" not in document
+            or "startRecording" not in document
+        ):
+            errors.append(f"{docs_file} must document the recorder settings contract")
 
     entitlements = read_text("CaptureSample/CaptureSample.entitlements")
     if "<plist version=\"1.0\">" not in entitlements:
@@ -223,6 +233,38 @@ def behavior_checks():
     player_viewer = read_text("CaptureSample/PlayerViewer.swift")
     persistence_controller = read_text("CaptureSample/PersistenceController.swift")
     menu_view = read_text("CaptureSample/Views/MenuView.swift")
+    swift_source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / "CaptureSample").rglob("*.swift"))
+    )
+
+    if "init(videoTransform: CGAffineTransform)" not in record:
+        errors.append("MovieRecorder must expose only the video transform at initialization")
+    if "private let videoTransform: CGAffineTransform" not in record:
+        errors.append("MovieRecorder must keep its initializer-only video transform immutable")
+    for ignored_fragment in (
+        "init(audioSettings:",
+        "private var audioSettings",
+        "private var videoSettings",
+        "MovieRecorder(audioSettings:",
+        "MovieRecorder(videoSettings:",
+    ):
+        if ignored_fragment in swift_source:
+            errors.append(f"MovieRecorder must not retain ignored settings fragment {ignored_fragment!r}")
+    initializer_call = "MovieRecorder(videoTransform: .identity)"
+    if swift_source.count(initializer_call) != 2:
+        errors.append("both recorder call sites must use the truthful video-transform initializer")
+    for fixed_setting in (
+        "AVFormatIDKey: kAudioFormatLinearPCM",
+        "AVSampleRateKey: 44100",
+        "AVNumberOfChannelsKey: 2",
+        "AVLinearPCMBitDepthKey: 16",
+        "AVVideoCodecKey: AVVideoCodecType.h264",
+        "AVVideoWidthKey: width",
+        "AVVideoHeightKey: height",
+    ):
+        if fixed_setting not in record:
+            errors.append(f"MovieRecorder must retain fixed writer setting {fixed_setting!r}")
 
     if "import ScreenCaptureKit" not in capture_engine:
         errors.append("CaptureEngine.swift must import ScreenCaptureKit")
@@ -442,6 +484,18 @@ def behavior_checks():
             if evidence not in audio_append_plan:
                 errors.append(
                     f"{AUDIO_APPEND_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+    if RECORDER_SETTINGS_PLAN.exists():
+        settings_plan = RECORDER_SETTINGS_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile recorder settings mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in settings_plan:
+                errors.append(
+                    f"{RECORDER_SETTINGS_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")


### PR DESCRIPTION
## Summary

`MovieRecorder` no longer advertises audio and video settings that it silently ignores. Its initializer now exposes only the video transform that is actually consumed, while the existing fixed PCM and H.264 writer settings remain unchanged inside recording startup.

Both production call sites use the truthful contract, and static verification prevents the ignored parameters, mutable transform, call-site drift, or codec-setting drift from returning.

## Test Plan

- `make check`
- External-directory `make check`
- Seven hostile recorder-settings mutations
- Hosted macOS build pending on the exact PR head

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
