### PR TITLE
fix: preserve explicit stop intent on appearance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - MovieRecorder exposes only its video transform at initialization; fixed audio
   and video output settings remain inside startRecording.
+- Preserved explicit user-stop intent when an authorized content view appears.
 
 ## 2026-06-15
 

--- a/CaptureSample/ContentView.swift
+++ b/CaptureSample/ContentView.swift
@@ -106,7 +106,9 @@ struct ContentView: View {
         .onAppear {
             Task {
                 if await screenRecorder.canRecord {
-                    await screenRecorder.start()
+                    if !userStopped {
+                        await screenRecorder.start()
+                    }
                 } else {
                     isUnauthorized = true
                     disableInput = true

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ lint:
 
 test:
 	$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode behavior
+	$(PYTHON) "$(ROOT)/scripts/test_user_stopped_autostart_contract.py"
 
 build: lint
 	@if command -v "$(XCODEBUILD)" >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   persistence when no completed URL exists.
 - Static behavior checks require awaited recording finalization so the recorder
   does not publish idle state before movie validation and persistence finish.
+- Authorized view appearance honors persisted explicit-stop intent before
+  automatically starting screen capture.
 - Static behavior checks preserve audio sample forwarding from accepted
   ScreenCaptureKit buffers to both live metering and the movie recorder.
 - Static behavior checks require the capture engine and stream output recorder
@@ -156,6 +158,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   free recorder handoff contract.
 - See `docs/plans/2026-06-13-awaited-recording-finalization.md` for the awaited
   recording finalization and persistence boundary.
+- See `docs/plans/2026-06-16-user-stopped-autostart-guard.md` for the persisted
+  explicit-stop auto-start boundary.
 - See `docs/plans/2026-06-13-audio-sample-forwarding.md` for the recorded-audio
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,8 @@ Helpful reports include:
   metering and movie-writer paths without adding a new capture source.
 - The capture engine and stream output use the caller-provided recorder handoff
   directly, avoiding a force unwrap in the recording startup path.
+- Authorized view appearance preserves persisted explicit-stop intent instead
+  of silently resuming screen capture.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -35,6 +35,7 @@ Priority:
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs
 - Keep awaited recording finalization ahead of recorder idle state
+- Keep persisted explicit-stop intent ahead of authorized appearance auto-start
 - Preserve audio sample forwarding to metering and movie output
 - Keep recorder handoff identity explicit and force-unwrap-free
 - Keep local Xcode signing team choices out of checked-in project metadata

--- a/docs/plans/2026-06-16-user-stopped-autostart-guard.md
+++ b/docs/plans/2026-06-16-user-stopped-autostart-guard.md
@@ -1,6 +1,6 @@
 # Preserve Explicit Stop Intent On App Appearance
 
-Status: Planned
+Status: Completed
 
 ## Context
 
@@ -38,3 +38,11 @@ persisted stop intent.
 - Record the Linux `xcodebuild` limitation without weakening static checks.
 - Audit the exact diff, generated artifacts, recording files, credential
   patterns, conflict markers, binaries, modes, and large files.
+
+## Verification Completed
+
+- The pre-fix source was rejected and four persisted-stop mutations were rejected.
+- The repository and external-directory `make check` passed all portable
+  project and behavior contracts; `xcodebuild` remained unavailable on Linux
+  and was reported truthfully.
+- Python syntax, exact-diff, generated-artifact, recording-file, and credential-pattern audits passed.

--- a/docs/plans/2026-06-16-user-stopped-autostart-guard.md
+++ b/docs/plans/2026-06-16-user-stopped-autostart-guard.md
@@ -1,0 +1,40 @@
+# Preserve Explicit Stop Intent On App Appearance
+
+Status: Planned
+
+## Context
+
+`ContentView` persists the user's explicit stop choice in `userStopped`, but
+its appearance task starts screen capture whenever permission is available.
+Relaunching or rebuilding the view can therefore resume capture despite the
+persisted stop intent.
+
+## Objectives
+
+- Keep permission validation as the outer prerequisite for capture.
+- Start capture on appearance only when `userStopped` is false.
+- Preserve the existing unauthorized overlay and input-disable behavior.
+- Add mutation-sensitive static coverage for guard presence, polarity, and
+  ordering before `screenRecorder.start()`.
+
+## Scope Boundaries
+
+- Do not change manual start/stop controls, timer behavior, recording output,
+  capture configuration, permissions, entitlements, or persistence schema.
+- Do not add generated recordings, build output, credentials, or dependencies.
+
+## Implementation
+
+1. Guard the authorized appearance auto-start with persisted `userStopped`.
+2. Extend the source checker through a focused reusable validator.
+3. Add hostile mutations for missing, inverted, and late guards.
+4. Synchronize repository guidance and record completed verification.
+
+## Verification
+
+- Prove the pre-fix source fails the new focused contract.
+- Run the focused mutation suite.
+- Run repository-root and external-directory `make check`.
+- Record the Linux `xcodebuild` limitation without weakening static checks.
+- Audit the exact diff, generated artifacts, recording files, credential
+  patterns, conflict markers, binaries, modes, and large files.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -4,6 +4,8 @@ import re
 import sys
 from pathlib import Path
 
+from user_stopped_autostart_contract import validation_errors
+
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS_PLANS = ROOT / "docs" / "plans"
@@ -21,6 +23,7 @@ RUNTIME_WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-runtime-writer-star
 VIDEO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-video-append-failure-propagation.md"
 AUDIO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-audio-append-failure-propagation.md"
 RECORDER_SETTINGS_PLAN = DOCS_PLANS / "2026-06-16-recorder-settings-contract.md"
+USER_STOPPED_AUTOSTART_PLAN = DOCS_PLANS / "2026-06-16-user-stopped-autostart-guard.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -48,6 +51,7 @@ def require_paths():
         str(VIDEO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
         str(AUDIO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
         str(RECORDER_SETTINGS_PLAN.relative_to(ROOT)),
+        str(USER_STOPPED_AUTOSTART_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -229,6 +233,7 @@ def behavior_checks():
     screen_recorder = read_text("CaptureSample/ScreenRecorder.swift")
     capture_app = read_text("CaptureSample/CaptureSampleApp.swift")
     content_view = read_text("CaptureSample/ContentView.swift")
+    errors.extend(validation_errors(content_view))
     record = read_text("CaptureSample/Record.swift")
     player_viewer = read_text("CaptureSample/PlayerViewer.swift")
     persistence_controller = read_text("CaptureSample/PersistenceController.swift")
@@ -496,6 +501,18 @@ def behavior_checks():
             if evidence not in settings_plan:
                 errors.append(
                     f"{RECORDER_SETTINGS_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+    if USER_STOPPED_AUTOSTART_PLAN.exists():
+        autostart_plan = USER_STOPPED_AUTOSTART_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "four persisted-stop mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in autostart_plan:
+                errors.append(
+                    f"{USER_STOPPED_AUTOSTART_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")

--- a/scripts/test_user_stopped_autostart_contract.py
+++ b/scripts/test_user_stopped_autostart_contract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from user_stopped_autostart_contract import validation_errors
+
+
+ROOT = Path(__file__).resolve().parents[1]
+baseline = (ROOT / "CaptureSample" / "ContentView.swift").read_text(encoding="utf-8")
+guard = "                    if !userStopped {\n"
+start = "                        await screenRecorder.start()\n"
+close = "                    }\n"
+
+errors = validation_errors(baseline)
+if errors:
+    raise AssertionError(f"baseline content view invalid: {errors}")
+
+mutations = {
+    "missing stop guard": baseline.replace(guard + start + close, start, 1),
+    "inverted stop guard": baseline.replace("if !userStopped {", "if userStopped {", 1),
+    "stop guard after start": baseline.replace(
+        guard + start,
+        start + guard,
+        1,
+    ),
+    "duplicate unguarded start": baseline.replace(
+        close + "                } else {",
+        close + "                    await screenRecorder.start()\n                } else {",
+        1,
+    ),
+}
+
+for description, source in mutations.items():
+    if not validation_errors(source):
+        raise AssertionError(f"{description} mutation was accepted")
+
+print(f"Persisted stop autostart contract passed ({len(mutations)} mutations rejected).")

--- a/scripts/user_stopped_autostart_contract.py
+++ b/scripts/user_stopped_autostart_contract.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+
+def validation_errors(source):
+    appearance_start = source.rfind(".onAppear {")
+    if appearance_start < 0:
+        return ["ContentView must retain its appearance task"]
+
+    appearance = source[appearance_start:]
+    permission_guard = "if await screenRecorder.canRecord {"
+    stop_guard = "if !userStopped {"
+    capture_start = "await screenRecorder.start()"
+    unauthorized_branch = "} else {"
+    required = (permission_guard, stop_guard, capture_start, unauthorized_branch)
+    positions = [appearance.find(fragment) for fragment in required]
+
+    if (
+        any(position < 0 for position in positions)
+        or positions != sorted(positions)
+        or appearance.count(capture_start) != 1
+    ):
+        return [
+            "ContentView must honor persisted stop intent before authorized appearance auto-start"
+        ]
+
+    return []


### PR DESCRIPTION
[![Built with Compound Engineering](https://img.shields.io/badge/built%20with-Compound%20Engineering-111827)](https://github.com/EveryInc/compound-engineering-plugin)

## Summary

Preserve a user's persisted explicit-stop choice when the authorized ScreenRecorder content view appears.

This PR is stacked on #12 and contains only the appearance auto-start privacy boundary.

## Baseline

`ContentView` persisted `userStopped`, but its appearance task started capture whenever ScreenCaptureKit permission was available. Relaunching or rebuilding the view could therefore resume capture after the user had explicitly stopped it.

## Improvements

- Keep permission validation as the outer prerequisite.
- Auto-start only when persisted `userStopped` is false.
- Add a reusable source validator and focused mutation suite.
- Synchronize the completed plan, README, security guidance, vision, and changelog.

## Validation

- Pre-fix source rejected by the persisted-stop contract.
- Four missing, inverted, late, and duplicate-start mutations rejected.
- Repository-root `make check` passed.
- External-directory `make -f /home/gjones/code/private/worktrees/screen-recorder-user-stopped-autostart-20260616/Makefile check` passed from `/tmp`.
- Project and behavior source checks passed.
- `xcodebuild` is unavailable on this Linux host and was explicitly reported without weakening portable checks.
- Exact diff, generated-artifact, recording-file, credential-pattern, conflict-marker, binary, mode, and large-file audits passed.

## Risk

Low and localized to automatic appearance startup. First-run/default behavior remains automatic when permission exists; an explicit persisted stop now requires a manual restart.

## Follow-Ups

- Exercise relaunch, window reconstruction, menu-bar start, and manual stop/start behavior on macOS.
- Keep PR #12 and this stacked PR open until maintainers choose the merge sequence.

## Post-Deploy Monitoring & Validation

- Require all exact-head hosted project and behavior jobs to pass for push and pull_request events.
- On macOS, stop recording, relaunch the app, and confirm capture remains stopped until the user starts it manually.
