### PR TITLE
Toggle recording from actual recorder state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Made the menu recording toggle follow actual recorder state and persist stop
+  intent before asynchronous start or stop work.
 - MovieRecorder exposes only its video transform at initialization; fixed audio
   and video output settings remain inside startRecording.
 - Preserved explicit user-stop intent when an authorized content view appears.

--- a/CaptureSample/Views/MenuView.swift
+++ b/CaptureSample/Views/MenuView.swift
@@ -23,16 +23,16 @@ struct MenuView: View {
                 HStack{
                     Spacer()
                     Button{
-                        if userStopped {
-                            Task {
-                                await screenRecorder.start()
-                            }
-                            self.userStopped = false
-                        } else {
+                        if screenRecorder.isRunning {
+                            self.userStopped = true
                             Task {
                                 await screenRecorder.stop()
                             }
-                            self.userStopped = true
+                        } else {
+                            self.userStopped = false
+                            Task {
+                                await screenRecorder.start()
+                            }
                         }
                     } label: {
                         VStack(alignment: .center){

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ lint:
 test:
 	$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode behavior
 	$(PYTHON) "$(ROOT)/scripts/test_user_stopped_autostart_contract.py"
+	$(PYTHON) "$(ROOT)/scripts/test_menu_recorder_state_contract.py"
 
 build: lint
 	@if command -v "$(XCODEBUILD)" >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   does not publish idle state before movie validation and persistence finish.
 - Authorized view appearance honors persisted explicit-stop intent before
   automatically starting screen capture.
+- The menu recording button chooses start or stop from live recorder state and
+  persists the matching intent before asynchronous work begins.
 - Static behavior checks preserve audio sample forwarding from accepted
   ScreenCaptureKit buffers to both live metering and the movie recorder.
 - Static behavior checks require the capture engine and stream output recorder
@@ -160,6 +162,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   recording finalization and persistence boundary.
 - See `docs/plans/2026-06-16-user-stopped-autostart-guard.md` for the persisted
   explicit-stop auto-start boundary.
+- See `docs/plans/2026-06-16-menu-recorder-state-toggle.md` for the state-driven
+  menu start/stop and persisted-intent ordering contract.
 - See `docs/plans/2026-06-13-audio-sample-forwarding.md` for the recorded-audio
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the

--- a/docs/plans/2026-06-16-menu-recorder-state-toggle.md
+++ b/docs/plans/2026-06-16-menu-recorder-state-toggle.md
@@ -1,6 +1,6 @@
 # Toggle Recording From Actual Recorder State
 
-Status: Planned
+Status: Completed
 
 ## Context
 
@@ -32,4 +32,13 @@ and requires a second click to restart.
 
 ## Verification
 
-- Pending implementation and portable validation.
+- The focused contract passed and six recorder-state mutations were rejected:
+  persisted intent choosing the operation, inverted stop intent, late stop
+  intent, inverted start intent, late start intent, and duplicate start.
+- The existing four persisted-stop autostart mutations remained rejected.
+- The repository and external-directory `make check` passed all portable
+  project and behavior contracts; `xcodebuild` remained unavailable on Linux
+  and was reported without weakening the static or hosted build boundary.
+- Exact diff, generated-artifact, recording-file, and credential-pattern audits passed.
+- No ScreenCaptureKit permission prompt, live capture, recording, playback, or
+  native macOS interaction was exercised locally.

--- a/docs/plans/2026-06-16-menu-recorder-state-toggle.md
+++ b/docs/plans/2026-06-16-menu-recorder-state-toggle.md
@@ -1,0 +1,35 @@
+# Toggle Recording From Actual Recorder State
+
+Status: Planned
+
+## Context
+
+The menu button chooses start or stop from persisted `userStopped` intent.
+After an unexpected capture failure, `ScreenRecorder.isRunning` is false while
+`userStopped` remains false, so the next Record click calls the no-op stop path
+and requires a second click to restart.
+
+## Requirements
+
+- Choose start or stop from `screenRecorder.isRunning`.
+- Persist stop intent before launching asynchronous stop work.
+- Clear stop intent before launching asynchronous start work.
+- Keep the existing button label and icon driven by recorder state.
+- Add mutation-sensitive static coverage for state selection, intent polarity,
+  and ordering before each task.
+- Keep validation portable on Linux without weakening the hosted macOS build.
+
+## Intended Files
+
+- `CaptureSample/Views/MenuView.swift`
+- `scripts/menu_recorder_state_contract.py`
+- `scripts/test_menu_recorder_state_contract.py`
+- `scripts/check-capture-source.py`
+- `Makefile`
+- `README.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-16-menu-recorder-state-toggle.md`
+
+## Verification
+
+- Pending implementation and portable validation.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -4,7 +4,8 @@ import re
 import sys
 from pathlib import Path
 
-from user_stopped_autostart_contract import validation_errors
+from menu_recorder_state_contract import validation_errors as menu_state_errors
+from user_stopped_autostart_contract import validation_errors as autostart_errors
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -24,6 +25,7 @@ VIDEO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-video-append-failure-propag
 AUDIO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-audio-append-failure-propagation.md"
 RECORDER_SETTINGS_PLAN = DOCS_PLANS / "2026-06-16-recorder-settings-contract.md"
 USER_STOPPED_AUTOSTART_PLAN = DOCS_PLANS / "2026-06-16-user-stopped-autostart-guard.md"
+MENU_RECORDER_STATE_PLAN = DOCS_PLANS / "2026-06-16-menu-recorder-state-toggle.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -52,6 +54,7 @@ def require_paths():
         str(AUDIO_APPEND_FAILURE_PLAN.relative_to(ROOT)),
         str(RECORDER_SETTINGS_PLAN.relative_to(ROOT)),
         str(USER_STOPPED_AUTOSTART_PLAN.relative_to(ROOT)),
+        str(MENU_RECORDER_STATE_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -233,11 +236,12 @@ def behavior_checks():
     screen_recorder = read_text("CaptureSample/ScreenRecorder.swift")
     capture_app = read_text("CaptureSample/CaptureSampleApp.swift")
     content_view = read_text("CaptureSample/ContentView.swift")
-    errors.extend(validation_errors(content_view))
+    errors.extend(autostart_errors(content_view))
     record = read_text("CaptureSample/Record.swift")
     player_viewer = read_text("CaptureSample/PlayerViewer.swift")
     persistence_controller = read_text("CaptureSample/PersistenceController.swift")
     menu_view = read_text("CaptureSample/Views/MenuView.swift")
+    errors.extend(menu_state_errors(menu_view))
     swift_source = "\n".join(
         path.read_text(encoding="utf-8")
         for path in sorted((ROOT / "CaptureSample").rglob("*.swift"))
@@ -513,6 +517,18 @@ def behavior_checks():
             if evidence not in autostart_plan:
                 errors.append(
                     f"{USER_STOPPED_AUTOSTART_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+    if MENU_RECORDER_STATE_PLAN.exists():
+        menu_state_plan = MENU_RECORDER_STATE_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "six recorder-state mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in menu_state_plan:
+                errors.append(
+                    f"{MENU_RECORDER_STATE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")

--- a/scripts/menu_recorder_state_contract.py
+++ b/scripts/menu_recorder_state_contract.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+
+def validation_errors(source):
+    action_start = source.find("Button{")
+    action_end = source.find("} label:", action_start)
+    if action_start < 0 or action_end < 0:
+        return ["MenuView must retain its recording button action"]
+
+    action = source[action_start:action_end]
+    required = (
+        "if screenRecorder.isRunning {",
+        "self.userStopped = true",
+        "await screenRecorder.stop()",
+        "} else {",
+        "self.userStopped = false",
+        "await screenRecorder.start()",
+    )
+    positions = [action.find(fragment) for fragment in required]
+    if any(position < 0 for position in positions) or positions != sorted(positions):
+        return [
+            "MenuView must toggle from recorder state and persist intent before async work"
+        ]
+
+    if action.count("await screenRecorder.stop()") != 1:
+        return ["MenuView must stop exactly once from the running branch"]
+    if action.count("await screenRecorder.start()") != 1:
+        return ["MenuView must start exactly once from the stopped branch"]
+
+    return []

--- a/scripts/test_menu_recorder_state_contract.py
+++ b/scripts/test_menu_recorder_state_contract.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from menu_recorder_state_contract import validation_errors
+
+
+ROOT = Path(__file__).resolve().parents[1]
+baseline = (ROOT / "CaptureSample" / "Views" / "MenuView.swift").read_text(
+    encoding="utf-8"
+)
+
+errors = validation_errors(baseline)
+if errors:
+    raise AssertionError(f"baseline menu view invalid: {errors}")
+
+mutations = {
+    "persisted intent chooses operation": baseline.replace(
+        "if screenRecorder.isRunning {", "if userStopped {", 1
+    ),
+    "inverted stop intent": baseline.replace(
+        "self.userStopped = true", "self.userStopped = false", 1
+    ),
+    "stop intent after task": baseline.replace(
+        "self.userStopped = true\n                            Task {\n"
+        "                                await screenRecorder.stop()\n"
+        "                            }",
+        "Task {\n                                await screenRecorder.stop()\n"
+        "                            }\n                            self.userStopped = true",
+        1,
+    ),
+    "inverted start intent": baseline.replace(
+        "self.userStopped = false", "self.userStopped = true", 1
+    ),
+    "start intent after task": baseline.replace(
+        "self.userStopped = false\n                            Task {\n"
+        "                                await screenRecorder.start()\n"
+        "                            }",
+        "Task {\n                                await screenRecorder.start()\n"
+        "                            }\n                            self.userStopped = false",
+        1,
+    ),
+    "duplicate start": baseline.replace(
+        "await screenRecorder.start()",
+        "await screenRecorder.start()\n                                await screenRecorder.start()",
+        1,
+    ),
+}
+
+for description, source in mutations.items():
+    if not validation_errors(source):
+        raise AssertionError(f"{description} mutation was accepted")
+
+print(f"Menu recorder-state contract passed ({len(mutations)} mutations rejected).")


### PR DESCRIPTION
## Summary

Make the menu recording control choose start or stop from the recorder's actual running state while persisting the matching user intent before asynchronous work begins.

## Baseline

The menu branched on `userStopped`. After an unexpected capture failure, `isRunning` was false while persisted intent remained false, so the next Record click called the no-op stop path and required a second click.

## Improvements

- Branch the menu action on `screenRecorder.isRunning`.
- Persist explicit stop intent before launching stop work and clear it before launching start work.
- Preserve the existing state-driven icon, label, and timer behavior.
- Add a reusable source validator and six hostile mutations for state selection, intent polarity, ordering, and duplicate starts.

## Validation

- Repository-root and external-directory `make check` passed.
- Project and behavior source contracts passed in both contexts.
- Four persisted-stop autostart mutations and six menu recorder-state mutations were rejected in both contexts.
- `xcodebuild` is unavailable on this Linux host; the existing hosted macOS build remains required.
- Exact diff, generated-artifact, recording-file, mode/binary, and secret-shaped added-line audits passed.

## Risk

The change is limited to menu action selection and persisted-intent ordering. Interactive ScreenCaptureKit permission, capture, recording, playback, and native UI behavior were not exercised locally.

## Follow-Ups

This PR is stacked on #13 and should retain base-first ordering. Do not merge or close either PR without explicit owner authorization.

