### PR TITLE
fix(recording): clean up stream delegate failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ built with ScreenCaptureKit.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-screen-recorder-macos-baseline.md` for the canonical capture and recording safety baseline.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Unexpected ScreenCaptureKit delegate stops propagate through the shared
+  recording cleanup path.
 - MovieRecorder exposes only its video transform at initialization; fixed audio
   and video output settings remain inside startRecording.
 - See `docs/plans/2026-06-08-local-player-viewer.md` for the local player viewer guard.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Unexpected ScreenCaptureKit delegate stops propagate through the shared
+  recording cleanup path so partial movie and stream state is released.
+
 ## 2026-06-16
 
 - Made the menu recording toggle follow actual recorder state and persist stop

--- a/CaptureSample/CaptureEngine.swift
+++ b/CaptureSample/CaptureEngine.swift
@@ -48,7 +48,7 @@ class CaptureEngine: NSObject, @unchecked Sendable {
         AsyncThrowingStream<CapturedFrame, Error> { continuation in
             self.continuation = continuation
             // The stream output object.
-            let streamOutput = CaptureEngineStreamOutput(continuation: continuation)
+            let streamOutput = CaptureEngineStreamOutput()
             streamOutput.movie = movie
             streamOutput.capturedFrameHandler = { continuation.yield($0) }
             streamOutput.pcmBufferHandler = { self.powerMeter.process(buffer: $0) }
@@ -134,13 +134,6 @@ private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDeleg
     var pcmBufferHandler: ((AVAudioPCMBuffer) -> Void)?
     var capturedFrameHandler: ((CapturedFrame) -> Void)?
     var recordingErrorHandler: ((Error) -> Void)?
-
-    // Store the the startCapture continuation, so you can cancel it if an error occurs.
-    private var continuation: AsyncThrowingStream<CapturedFrame, Error>.Continuation?
-
-    init(continuation: AsyncThrowingStream<CapturedFrame, Error>.Continuation?) {
-        self.continuation = continuation
-    }
 
     /// - Tag: DidOutputSampleBuffer
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of outputType: SCStreamOutputType) {
@@ -231,6 +224,6 @@ private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDeleg
     }
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
-        continuation?.finish(throwing: error)
+        recordingErrorHandler?(error)
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test:
 	$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode behavior
 	$(PYTHON) "$(ROOT)/scripts/test_user_stopped_autostart_contract.py"
 	$(PYTHON) "$(ROOT)/scripts/test_menu_recorder_state_contract.py"
+	$(PYTHON) "$(ROOT)/scripts/test_stream_delegate_failure_contract.py"
 
 build: lint
 	@if command -v "$(XCODEBUILD)" >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - A video sample append failure follows the same cleanup path instead of
   allowing capture to continue with a failed movie writer.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Unexpected ScreenCaptureKit delegate stops propagate through the shared
+  recording cleanup path so partial movies, continuations, and retained streams
+  are not left active.
 - Static behavior checks require recording finalization to return only
   completed movie URLs, remove failed partial files, and skip recording-history
   persistence when no completed URL exists.
@@ -164,6 +167,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   explicit-stop auto-start boundary.
 - See `docs/plans/2026-06-16-menu-recorder-state-toggle.md` for the state-driven
   menu start/stop and persisted-intent ordering contract.
+- See `docs/plans/2026-06-17-stream-delegate-failure-cleanup.md` for unexpected
+  stream-stop routing through shared recording cleanup.
 - See `docs/plans/2026-06-13-audio-sample-forwarding.md` for the recorded-audio
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,8 @@ Helpful reports include:
 - A video sample append failure must propagate through the same cleanup boundary
   instead of allowing capture to continue after the writer rejects a frame.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Unexpected ScreenCaptureKit delegate stops propagate through the shared
+  recording cleanup path so partial local output is cancelled.
 - Recording finalization persists history only after the asset writer reports
   completion; failed partial files are removed without logging their URLs.
 - Awaited recording finalization keeps stop completion and idle-state publication

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,8 @@ Priority:
 - Stop active capture when a runtime writer start failure rejects the first frame
 - Propagate video sample append failure through the existing recording cleanup path
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Unexpected ScreenCaptureKit delegate stops propagate through the shared
+  recording cleanup path.
 - Remove unfinished movie files when capture setup fails
 - Persist recording history only after successful movie finalization and remove
   failed partial outputs

--- a/docs/plans/2026-06-17-stream-delegate-failure-cleanup.md
+++ b/docs/plans/2026-06-17-stream-delegate-failure-cleanup.md
@@ -1,0 +1,76 @@
+---
+title: Route Stream Delegate Failures Through Recording Cleanup
+type: fix
+date: 2026-06-17
+---
+
+# Route Stream Delegate Failures Through Recording Cleanup
+
+Status: In Progress
+
+## Context
+
+Video and audio append failures already use `CaptureEngine.failCapture(_:)` to
+cancel the partial movie, finish the engine continuation, clear the retained
+stream, and stop capture. `SCStreamDelegate.didStopWithError` instead finishes
+a second continuation owned by the stream output, bypassing that cleanup and
+leaving recorder state or a partial movie retained after an unexpected stream
+stop.
+
+## Requirements
+
+- R1. Route unexpected `SCStreamDelegate` stop errors through the shared
+  recording failure handler.
+- R2. Cancel partial movie output, finish the engine continuation, clear the
+  retained stream, and attempt stream shutdown through the existing cleanup
+  path.
+- R3. Remove the stream output's duplicate continuation so delegate and sample
+  failures cannot diverge again.
+- R4. Preserve normal stop behavior and the existing video/audio append-failure
+  paths.
+- R5. Add mutation-sensitive offline coverage that rejects direct continuation
+  completion, swallowed delegate failures, duplicate continuation state, and
+  broken cleanup routing.
+- R6. Keep Linux validation portable and require the hosted macOS build for
+  Apple-framework compilation evidence.
+
+## Scope Boundaries
+
+- Do not redesign recorder ownership, normal finalization, or menu state.
+- Do not add dependencies or weaken the existing static and hosted build gates.
+
+## Implementation Units
+
+### U1. Characterize the delegate cleanup bypass
+
+- **Goal:** Define the required delegate-to-handler routing and reject the
+  current direct-continuation path.
+- **Files:** `scripts/stream_delegate_failure_contract.py`,
+  `scripts/test_stream_delegate_failure_contract.py`
+- **Verification:** The focused baseline fails before the source fix and each
+  hostile mutation is rejected afterward.
+
+### U2. Unify stream failure cleanup
+
+- **Goal:** Route `didStopWithError` through `recordingErrorHandler` and remove
+  the stream output continuation that is no longer needed.
+- **Files:** `CaptureSample/CaptureEngine.swift`
+- **Verification:** Focused contract plus the complete portable repository
+  gate.
+
+### U3. Make the boundary durable
+
+- **Goal:** Register the contract, document the lifecycle behavior, and record
+  completed evidence.
+- **Files:** `scripts/check-capture-source.py`, `Makefile`, `README.md`,
+  `CHANGES.md`, `AGENTS.md`,
+  `docs/plans/2026-06-17-stream-delegate-failure-cleanup.md`
+- **Verification:** Repository and external-directory `make check`, explicit
+  mutation checks, and generated-artifact, recording-file, and credential
+  audits.
+
+## Verification
+
+- Planned: focused delegate-failure contract and hostile mutations.
+- Planned: repository and external-directory `make check` on Linux.
+- Planned: hosted macOS build on the exact pushed head.

--- a/docs/plans/2026-06-17-stream-delegate-failure-cleanup.md
+++ b/docs/plans/2026-06-17-stream-delegate-failure-cleanup.md
@@ -6,7 +6,7 @@ date: 2026-06-17
 
 # Route Stream Delegate Failures Through Recording Cleanup
 
-Status: In Progress
+Status: Completed
 
 ## Context
 
@@ -71,6 +71,13 @@ stop.
 
 ## Verification
 
-- Planned: focused delegate-failure contract and hostile mutations.
-- Planned: repository and external-directory `make check` on Linux.
-- Planned: hosted macOS build on the exact pushed head.
+- The focused contract passed and six stream-delegate mutations were rejected:
+  direct continuation completion, swallowed delegate failure, duplicate
+  continuation state, restored continuation initialization, removed shared
+  handler wiring, and duplicate delegate cleanup.
+- The existing persisted-stop and menu-state contracts still rejected all ten
+  of their mutations.
+- The repository and external-directory `make check` passed on Linux; the
+  portable gate completed and reported the expected unavailable `xcodebuild`.
+- Exact-diff, generated-artifact, recording-file, and credential-pattern audits passed.
+- The hosted macOS build remains required on the exact pushed head.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from menu_recorder_state_contract import validation_errors as menu_state_errors
+from stream_delegate_failure_contract import validation_errors as stream_delegate_errors
 from user_stopped_autostart_contract import validation_errors as autostart_errors
 
 
@@ -26,6 +27,7 @@ AUDIO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-audio-append-failure-propag
 RECORDER_SETTINGS_PLAN = DOCS_PLANS / "2026-06-16-recorder-settings-contract.md"
 USER_STOPPED_AUTOSTART_PLAN = DOCS_PLANS / "2026-06-16-user-stopped-autostart-guard.md"
 MENU_RECORDER_STATE_PLAN = DOCS_PLANS / "2026-06-16-menu-recorder-state-toggle.md"
+STREAM_DELEGATE_FAILURE_PLAN = DOCS_PLANS / "2026-06-17-stream-delegate-failure-cleanup.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -55,6 +57,7 @@ def require_paths():
         str(RECORDER_SETTINGS_PLAN.relative_to(ROOT)),
         str(USER_STOPPED_AUTOSTART_PLAN.relative_to(ROOT)),
         str(MENU_RECORDER_STATE_PLAN.relative_to(ROOT)),
+        str(STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)),
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -170,6 +173,7 @@ def project_checks():
     for fragment in (
         root_declaration,
         '$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode project',
+        '$(PYTHON) "$(ROOT)/scripts/test_stream_delegate_failure_contract.py"',
         'cd "$(ROOT)" && "$(XCODEBUILD)" -project ScreenRecorder.xcodeproj',
         "CODE_SIGNING_ALLOWED=NO build",
     ):
@@ -209,9 +213,12 @@ def project_checks():
         if "video sample append failure" not in document.lower():
             errors.append(f"{docs_file} must document video sample append failure propagation")
     for docs_file in ("AGENTS.md", "README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
-        if "Video and audio sample append failures propagate through the shared recording cleanup path." not in read_text(docs_file):
+        raw_document = read_text(docs_file)
+        if "Video and audio sample append failures propagate through the shared recording cleanup path." not in raw_document:
             errors.append(f"{docs_file} must document shared video/audio append failure cleanup")
-        document = " ".join(read_text(docs_file).split())
+        document = " ".join(raw_document.split())
+        if "Unexpected ScreenCaptureKit delegate stops propagate through the shared recording cleanup path" not in document:
+            errors.append(f"{docs_file} must document stream delegate failure cleanup")
         if (
             "MovieRecorder" not in document
             or "video transform" not in document
@@ -233,6 +240,7 @@ def behavior_checks():
         return errors
 
     capture_engine = read_text("CaptureSample/CaptureEngine.swift")
+    errors.extend(stream_delegate_errors(capture_engine))
     screen_recorder = read_text("CaptureSample/ScreenRecorder.swift")
     capture_app = read_text("CaptureSample/CaptureSampleApp.swift")
     content_view = read_text("CaptureSample/ContentView.swift")
@@ -530,6 +538,22 @@ def behavior_checks():
                 errors.append(
                     f"{MENU_RECORDER_STATE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
+    if STREAM_DELEGATE_FAILURE_PLAN.exists():
+        stream_delegate_plan = STREAM_DELEGATE_FAILURE_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "six stream-delegate mutations were rejected",
+            "generated-artifact, recording-file, and credential-pattern audits passed",
+        ):
+            if evidence not in stream_delegate_plan:
+                errors.append(
+                    f"{STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+        if str(STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+            errors.append(
+                f"README.md must reference {STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)}"
+            )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")
     if "Text(screenRecorder.timerString)" not in capture_app:

--- a/scripts/stream_delegate_failure_contract.py
+++ b/scripts/stream_delegate_failure_contract.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+
+def validation_errors(source):
+    output_marker = "private class CaptureEngineStreamOutput"
+    if output_marker not in source:
+        return ["CaptureEngineStreamOutput must remain defined"]
+
+    engine, output = source.split(output_marker, 1)
+    errors = []
+
+    creation = engine.find("let streamOutput = CaptureEngineStreamOutput()")
+    handler = engine.find(
+        "streamOutput.recordingErrorHandler = { [weak self] error in\n"
+        "                self?.failCapture(error)"
+    )
+    stream = engine.find("stream = SCStream(")
+    if min(creation, handler, stream) < 0 or not creation < handler < stream:
+        errors.append(
+            "CaptureEngine must wire shared failure cleanup before creating the stream"
+        )
+
+    if "init(continuation:" in output or "private var continuation:" in output:
+        errors.append(
+            "CaptureEngineStreamOutput must not retain a duplicate stream continuation"
+        )
+
+    method_start = output.find(
+        "func stream(_ stream: SCStream, didStopWithError error: Error) {"
+    )
+    method_end = output.find("\n    }", method_start)
+    if method_start < 0 or method_end < 0:
+        errors.append("CaptureEngineStreamOutput must handle delegate stop failures")
+        return errors
+
+    method = output[method_start:method_end]
+    if method.count("recordingErrorHandler?(error)") != 1:
+        errors.append(
+            "SCStreamDelegate stop failures must reach shared recording cleanup exactly once"
+        )
+    if "continuation" in method:
+        errors.append(
+            "SCStreamDelegate stop failures must not finish a private continuation directly"
+        )
+
+    return errors

--- a/scripts/test_stream_delegate_failure_contract.py
+++ b/scripts/test_stream_delegate_failure_contract.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from stream_delegate_failure_contract import validation_errors
+
+
+ROOT = Path(__file__).resolve().parents[1]
+baseline = (ROOT / "CaptureSample" / "CaptureEngine.swift").read_text(
+    encoding="utf-8"
+)
+
+errors = validation_errors(baseline)
+if errors:
+    raise AssertionError(f"baseline stream delegate failure cleanup invalid: {errors}")
+
+delegate_method = (
+    "func stream(_ stream: SCStream, didStopWithError error: Error) {\n"
+    "        recordingErrorHandler?(error)\n"
+    "    }"
+)
+
+mutations = {
+    "direct continuation completion": baseline.replace(
+        delegate_method,
+        "func stream(_ stream: SCStream, didStopWithError error: Error) {\n"
+        "        continuation?.finish(throwing: error)\n"
+        "    }",
+        1,
+    ),
+    "swallowed delegate failure": baseline.replace(
+        delegate_method,
+        "func stream(_ stream: SCStream, didStopWithError error: Error) {\n"
+        "        return\n"
+        "    }",
+        1,
+    ),
+    "duplicate continuation state": baseline.replace(
+        "private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDelegate {\n"
+        "    private let logger = Logger()",
+        "private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDelegate {\n"
+        "    private let logger = Logger()\n"
+        "    private var continuation: AsyncThrowingStream<CapturedFrame, Error>.Continuation?",
+        1,
+    ),
+    "continuation initializer restored": baseline.replace(
+        "let streamOutput = CaptureEngineStreamOutput()",
+        "let streamOutput = CaptureEngineStreamOutput(continuation: continuation)",
+        1,
+    ),
+    "shared handler wiring removed": baseline.replace(
+        "            streamOutput.recordingErrorHandler = { [weak self] error in\n"
+        "                self?.failCapture(error)\n"
+        "            }\n",
+        "",
+        1,
+    ),
+    "duplicate delegate cleanup": baseline.replace(
+        delegate_method,
+        "func stream(_ stream: SCStream, didStopWithError error: Error) {\n"
+        "        recordingErrorHandler?(error)\n"
+        "        recordingErrorHandler?(error)\n"
+        "    }",
+        1,
+    ),
+}
+
+for description, source in mutations.items():
+    if not validation_errors(source):
+        raise AssertionError(f"{description} mutation was accepted")
+
+print(
+    "Stream delegate failure cleanup contract passed "
+    f"({len(mutations)} mutations rejected)."
+)


### PR DESCRIPTION
## Summary

Unexpected ScreenCaptureKit stop errors now release the same recording resources as video and audio append failures. Previously the delegate completed a private continuation directly, leaving the partial movie writer and retained stream outside the shared cleanup path.

## Baseline

This PR is stacked on #14 and reuses the existing `CaptureEngine.failCapture(_:)` lifecycle. Normal stop/finalization, recorder ownership, menu state, and sample append handling remain unchanged.

## Improvements

- Route `didStopWithError` through the shared recording failure handler.
- Remove the stream output’s duplicate continuation so failure paths cannot diverge.
- Lock delegate routing, handler ordering, and single-delivery behavior with a six-mutation contract.
- Keep the lifecycle contract documented across maintenance, security, and verification guidance.

## Validation

- Repository and external-directory `make check` on Linux
- Project and behavior static checks
- Persisted-stop contract: 4 mutations rejected
- Menu recorder-state contract: 6 mutations rejected
- Stream delegate failure cleanup contract: 6 mutations rejected
- Exact eleven-path diff, generated-artifact, recording-file, mode/binary, and credential-pattern audits

`swiftc`, `xcodebuild`, and XcodeBuildMCP are unavailable in the Linux workspace. The exact-head hosted macOS build remains the Apple-framework compilation authority.

## Risk

The delegate now invokes the same optional handler already wired for sample recording failures. The primary residual risk is macOS compile/runtime compatibility, covered by the canonical hosted build; no recording permissions, live capture, or output file was exercised locally.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this is a local macOS sample rather than a deployed service. During the first manual recording session, the maintainer should interrupt or revoke an active capture and confirm the UI stops, no recording metadata is saved, and no partial movie remains.

## Follow-Ups

- Merge the stacked base PR before this PR; do not merge or close either automatically.
- Retain the hosted macOS build as required evidence before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
