### PR TITLE
Harden Make verification authority

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,9 @@
 
 ## 2026-06-21
 
-- Isolated Make verification authority from caller-controlled preload files,
-  file lists, shells, Python commands, Xcode builders, bytecode settings, and
-  repository roots, with 66 target/authority cases and rejection coverage.
+- Isolated repository recipes from caller-controlled roots, shells, tool
+  variables, executable shadowing, Python startup state, and bytecode settings,
+  with 66 target/authority cases and explicit GNU Make startup-boundary notes.
 
 ## 2026-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Isolated Make verification authority from caller-controlled preload files,
+  file lists, shells, Python commands, Xcode builders, bytecode settings, and
+  repository roots, with 66 target/authority cases and rejection coverage.
+
 ## 2026-06-19
 
 - Appended the first video sample after starting the asset writer session so

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,45 @@
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+.PHONY: build check lint root-test test verify
 
-PYTHON ?= python3
-XCODEBUILD ?= xcodebuild
-
-.PHONY: build check lint test verify
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+override PYTHON := python3
+override XCODEBUILD := xcodebuild
+override PYTHONDONTWRITEBYTECODE := 1
+export PYTHONDONTWRITEBYTECODE
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
 
 lint:
-	$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode project
+	$(PYTHON) "$$ROOT/scripts/check-capture-source.py" --mode project
 
 test:
-	$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode behavior
-	$(PYTHON) "$(ROOT)/scripts/test_movie_recorder_video_start_contract.py"
-	$(PYTHON) "$(ROOT)/scripts/test_screen_recorder_start_stop_contract.py"
-	$(PYTHON) "$(ROOT)/scripts/test_user_stopped_autostart_contract.py"
-	$(PYTHON) "$(ROOT)/scripts/test_menu_recorder_state_contract.py"
-	$(PYTHON) "$(ROOT)/scripts/test_stream_delegate_failure_contract.py"
+	$(PYTHON) "$$ROOT/scripts/check-capture-source.py" --mode behavior
+	$(PYTHON) "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"
+	$(PYTHON) "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"
+	$(PYTHON) "$$ROOT/scripts/test_user_stopped_autostart_contract.py"
+	$(PYTHON) "$$ROOT/scripts/test_menu_recorder_state_contract.py"
+	$(PYTHON) "$$ROOT/scripts/test_stream_delegate_failure_contract.py"
 
 build: lint
-	@if command -v "$(XCODEBUILD)" >/dev/null 2>&1; then \
-		cd "$(ROOT)" && "$(XCODEBUILD)" -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
+	@if command -v $(XCODEBUILD) >/dev/null 2>&1; then \
+		cd "$$ROOT" && $(XCODEBUILD) -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "xcodebuild not found; static project checks completed"; \
 	fi
 
-verify: lint test build
+root-test:
+	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
+
+verify: root-test lint test build
 
 check: verify

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 override SHELL := /bin/sh
 override .SHELLFLAGS := -c
-override PYTHON := python3
-override XCODEBUILD := xcodebuild
 override PYTHONDONTWRITEBYTECODE := 1
 export PYTHONDONTWRITEBYTECODE
 ifneq ($(strip $(MAKEFILES)),)
@@ -18,21 +16,24 @@ export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
 endif
+override PYTHON := $(ROOT)/scripts/run-python.sh
+override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh
+export PYTHON XCODEBUILD
 
 lint:
-	$(PYTHON) "$$ROOT/scripts/check-capture-source.py" --mode project
+	"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode project
 
 test:
-	$(PYTHON) "$$ROOT/scripts/check-capture-source.py" --mode behavior
-	$(PYTHON) "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"
-	$(PYTHON) "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"
-	$(PYTHON) "$$ROOT/scripts/test_user_stopped_autostart_contract.py"
-	$(PYTHON) "$$ROOT/scripts/test_menu_recorder_state_contract.py"
-	$(PYTHON) "$$ROOT/scripts/test_stream_delegate_failure_contract.py"
+	"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode behavior
+	"$$PYTHON" "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"
+	"$$PYTHON" "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"
+	"$$PYTHON" "$$ROOT/scripts/test_user_stopped_autostart_contract.py"
+	"$$PYTHON" "$$ROOT/scripts/test_menu_recorder_state_contract.py"
+	"$$PYTHON" "$$ROOT/scripts/test_stream_delegate_failure_contract.py"
 
 build: lint
-	@if command -v $(XCODEBUILD) >/dev/null 2>&1; then \
-		cd "$$ROOT" && $(XCODEBUILD) -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
+	@if [ -x /usr/bin/xcodebuild ]; then \
+		cd "$$ROOT" && "$$XCODEBUILD" -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "xcodebuild not found; static project checks completed"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - `make check` runs static project/source checks. When `xcodebuild` is
   installed, the `build` target also runs the shared Xcode scheme with code
   signing disabled.
+- `make root-test` proves every public Make target keeps its repository root,
+  shell, Python checker, Xcode builder, and bytecode policy under repository
+  control while rejecting preload and Makefile-list overrides.
 - GitHub Actions runs `make check` through `.github/workflows/check.yml` on
   all branch pushes, pull requests, and manual dispatches with pinned Node
   24-compatible actions, read-only permissions, disabled checkout credential
@@ -173,6 +176,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent capture verification root.
+- See `docs/plans/2026-06-21-make-authority-isolation.md` for isolated Make
+  authority and hostile-input regression coverage.
 - See `docs/plans/2026-06-14-writer-start-failure-propagation.md` for the
   fail-closed movie-writer startup boundary.
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   installed, the `build` target also runs the shared Xcode scheme with code
   signing disabled.
 - `make root-test` proves every public Make target keeps its repository root,
-  shell, Python checker, Xcode builder, and bytecode policy under repository
-  control while rejecting preload and Makefile-list overrides.
+  shell, repository-owned isolated Python launcher, absolute Xcode launcher,
+  and bytecode policy under repository control while detecting unsupported
+  preload and Makefile-list inputs before repository recipes execute.
+  Standard in-checkout invocation supports literal dollar and command-syntax
+  path characters; an absolute `--file` path containing `$` is unsupported
+  because GNU Make expands it before `MAKEFILE_LIST` can expose the filename.
 - GitHub Actions runs `make check` through `.github/workflows/check.yml` on
   all branch pushes, pull requests, and manual dispatches with pinned Node
   24-compatible actions, read-only permissions, disabled checkout credential
@@ -176,8 +180,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent capture verification root.
-- See `docs/plans/2026-06-21-make-authority-isolation.md` for isolated Make
-  authority and hostile-input regression coverage.
+- See `docs/plans/2026-06-21-make-authority-isolation.md` for the supported
+  Make authority boundary and hostile-input regression coverage.
 - See `docs/plans/2026-06-14-writer-start-failure-propagation.md` for the
   fail-closed movie-writer startup boundary.
 

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -13,7 +13,9 @@ check` can redirect those commands away from the checkout.
 
 - **R1:** Prevent command-line and environment values from replacing the
   Makefile-derived repository root.
-- **R2:** Keep `PYTHON` and `XCODEBUILD` configurable.
+- **R2:** Keep the documented Python and Xcode tools. The Make
+  authority-isolation follow-up fixed both command names because they are part
+  of the trusted verification boundary.
 - **R3:** Require the exact protected declaration in the capture checker.
 - **R4:** Prove every public Make alias from the checkout and an external
   directory with a hostile `ROOT` argument.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -1,0 +1,36 @@
+# Make Authority Isolation
+
+## Status: Completed
+
+## Context
+
+The protected repository root stopped direct `ROOT=/tmp` redirection, but GNU
+Make still accepted caller-controlled preload files, file lists, recipe shells,
+Python commands, and Xcode build commands. Those channels could replace static
+contracts or turn the hosted native build into a no-op.
+
+## Requirements
+
+- **R1:** Load the repository Makefile alone and reject overridden file lists.
+- **R2:** Derive the checkout root safely from the exact Makefile path.
+- **R3:** Fix the shell, Python command, Xcode build command, and bytecode
+  suppression.
+- **R4:** Exercise every public target across hostile authority inputs.
+- **R5:** Preserve all Swift, project, capture, recording, and signing behavior.
+
+## Implementation
+
+- Hardened Make authority before target definitions are evaluated.
+- Added a macOS-portable `root-test` checkout with spaces, quotes, and
+  command-substitution syntax in its path.
+- Covered all six public targets across eleven authority modes plus explicit
+  file-list, preload, and multiple-Makefile rejection cases.
+- Left Swift source, Xcode project, entitlements, and application behavior
+  unchanged.
+
+## Verification
+
+- `make root-test` passed 66 target/authority cases and four rejection cases.
+- `make check` passed from the repository and through an absolute Makefile path.
+- Python and shell syntax checks, `git diff --check`, and repository integrity
+  screening passed.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -4,33 +4,51 @@
 
 ## Context
 
-The protected repository root stopped direct `ROOT=/tmp` redirection, but GNU
-Make still accepted caller-controlled preload files, file lists, recipe shells,
-Python commands, and Xcode build commands. Those channels could replace static
-contracts or turn the hosted native build into a no-op.
+The protected repository root stopped direct `ROOT=/tmp` redirection, but the
+repository recipes still accepted caller-controlled shells and tool variables,
+and bare tool names could be replaced through `PATH`. Those channels could
+replace static contracts or turn the hosted native build into a no-op.
 
 ## Requirements
 
-- **R1:** Load the repository Makefile alone and reject overridden file lists.
+- **R1:** Detect unsupported preload and file-list inputs before repository
+  recipes execute, without claiming to undo GNU Make parse-time side effects.
 - **R2:** Derive the checkout root safely from the exact Makefile path.
-- **R3:** Fix the shell, Python command, Xcode build command, and bytecode
-  suppression.
+- **R3:** Fix the shell, repository-owned isolated Python launcher, absolute
+  Xcode launcher, and bytecode suppression without trusting `PATH`.
 - **R4:** Exercise every public target across hostile authority inputs.
 - **R5:** Preserve all Swift, project, capture, recording, and signing behavior.
 
 ## Implementation
 
-- Hardened Make authority before target definitions are evaluated.
+- Hardened repository recipe authority before targets execute.
+- Added repository-owned launchers that use `/usr/bin/python3 -I -B` and
+  `/usr/bin/xcodebuild`, preventing `PATH` and Python startup-state shadowing.
 - Added a macOS-portable `root-test` checkout with spaces, quotes, and
   command-substitution syntax in its path.
 - Covered all six public targets across eleven authority modes plus explicit
-  file-list, preload, and multiple-Makefile rejection cases.
+  file-list/preload rejection and earlier-file detection cases.
 - Left Swift source, Xcode project, entitlements, and application behavior
   unchanged.
 
+## Boundary
+
+GNU Make evaluates `MAKEFILES`, `--eval`, and additional `--file` inputs while
+it is constructing the build graph. A Makefile cannot prevent code in those
+explicit startup inputs from running before or after that Makefile is parsed.
+They are therefore unsupported caller-selected programs, not trusted
+verification inputs. The repository detects the cases visible when its own
+file is parsed and fails before repository recipes execute; CI and documented
+usage invoke `make check` without extra startup code.
+
+GNU Make also expands dollar syntax in an absolute `--file` argument before
+recording `MAKEFILE_LIST`. Repositories whose path contains `$` therefore use
+the documented in-checkout `make check` form; that form is covered with a
+literal `$(...)` directory name and does not execute the path text.
+
 ## Verification
 
-- `make root-test` passed 66 target/authority cases and four rejection cases.
+- `make root-test` passed 66 target/authority cases, one dollar-syntax checkout case, three override rejections, and one earlier-file detection.
 - `make check` passed from the repository and through an absolute Makefile path.
 - Python and shell syntax checks, `git diff --check`, and repository integrity
   screening passed.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -22,6 +22,7 @@ RECORDING_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-12-recording-finalization-in
 AWAITED_FINALIZATION_PLAN = DOCS_PLANS / "2026-06-13-awaited-recording-finalization.md"
 AUDIO_FORWARDING_PLAN = DOCS_PLANS / "2026-06-13-audio-sample-forwarding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
+MAKE_AUTHORITY_PLAN = DOCS_PLANS / "2026-06-21-make-authority-isolation.md"
 WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-writer-start-failure-propagation.md"
 RUNTIME_WRITER_START_FAILURE_PLAN = DOCS_PLANS / "2026-06-14-runtime-writer-start-failure.md"
 VIDEO_APPEND_FAILURE_PLAN = DOCS_PLANS / "2026-06-15-video-append-failure-propagation.md"
@@ -91,6 +92,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-13-audio-sample-forwarding.md is missing")
     if not MAKE_ROOT_PLAN.exists():
         errors.append("docs/plans/2026-06-14-make-root-override-protection.md is missing")
+    if not MAKE_AUTHORITY_PLAN.exists():
+        errors.append("docs/plans/2026-06-21-make-authority-isolation.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -162,26 +165,36 @@ def project_checks():
                 errors.append(f"GitHub Actions action {action} must be pinned to a full commit SHA")
 
     makefile = MAKEFILE.read_text(encoding="utf-8") if MAKEFILE.exists() else ""
-    root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+    root_declaration = "override ROOT := $(shell path='$(subst ','\"'\"',$(MAKEFILE_LIST))'; path=$$(printf '%s' \"$$path\" | /usr/bin/sed 's/^ //'); [ -f \"$$path\" ] || exit 1; directory=$$(/usr/bin/dirname -- \"$$path\"); CDPATH= cd -- \"$$directory\" && /bin/pwd -P)"
     root_assignments = [
         line
         for line in makefile.splitlines()
         if re.match(r"^(?:override\s+)?ROOT\s*[:?+]?=", line)
     ]
-    if not makefile.startswith(f"{root_declaration}\n") or root_assignments != [
-        root_declaration
-    ]:
-        errors.append(
-            "Makefile must define exactly one protected repository-derived ROOT declaration first"
-        )
+    if root_assignments != [root_declaration]:
+        errors.append("Makefile must define exactly one safe repository-derived ROOT declaration")
     for fragment in (
+        "override SHELL := /bin/sh",
+        "override .SHELLFLAGS := -c",
+        "override PYTHON := python3",
+        "override XCODEBUILD := xcodebuild",
+        "override PYTHONDONTWRITEBYTECODE := 1",
+        "export PYTHONDONTWRITEBYTECODE",
+        "$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)",
+        "override MAKEFILES :=",
+        "$(error MAKEFILE_LIST must not be overridden)",
         root_declaration,
-        '$(PYTHON) "$(ROOT)/scripts/check-capture-source.py" --mode project',
-        '$(PYTHON) "$(ROOT)/scripts/test_movie_recorder_video_start_contract.py"',
-        '$(PYTHON) "$(ROOT)/scripts/test_screen_recorder_start_stop_contract.py"',
-        '$(PYTHON) "$(ROOT)/scripts/test_stream_delegate_failure_contract.py"',
-        'cd "$(ROOT)" && "$(XCODEBUILD)" -project ScreenRecorder.xcodeproj',
+        "export ROOT",
+        "$(error repository Makefile path could not be resolved)",
+        '$(PYTHON) "$$ROOT/scripts/check-capture-source.py" --mode project',
+        '$(PYTHON) "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"',
+        '$(PYTHON) "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"',
+        '$(PYTHON) "$$ROOT/scripts/test_stream_delegate_failure_contract.py"',
+        'cd "$$ROOT" && $(XCODEBUILD) -project ScreenRecorder.xcodeproj',
         "CODE_SIGNING_ALLOWED=NO build",
+        "root-test:",
+        '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"',
+        "verify: root-test lint test build",
     ):
         if fragment not in makefile:
             errors.append(f"Makefile must keep contract: {fragment}")
@@ -201,6 +214,32 @@ def project_checks():
                 )
         if str(MAKE_ROOT_PLAN.relative_to(ROOT)) not in read_text("README.md"):
             errors.append(f"README.md must reference {MAKE_ROOT_PLAN.relative_to(ROOT)}")
+
+    root_test = ROOT / "scripts" / "test-makefile-root.sh"
+    if root_test.exists():
+        root_test_text = root_test.read_text(encoding="utf-8")
+        for evidence in (
+            "66 executed target/authority cases",
+            "MAKEFILE_LIST must not be overridden",
+            "MAKEFILES must be empty",
+            "repository Makefile path could not be resolved",
+        ):
+            if evidence not in root_test_text:
+                errors.append(f"{root_test.relative_to(ROOT)} must preserve {evidence!r}")
+    else:
+        errors.append("scripts/test-makefile-root.sh is missing")
+
+    if MAKE_AUTHORITY_PLAN.exists():
+        authority_plan = MAKE_AUTHORITY_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "`make root-test` passed 66 target/authority cases and four rejection cases",
+            "`make check` passed from the repository and through an absolute Makefile path",
+        ):
+            if evidence not in authority_plan:
+                errors.append(
+                    f"{MAKE_AUTHORITY_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
 
     for docs_file in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         document = read_text(docs_file)

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -63,6 +63,8 @@ def require_paths():
         str(STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)),
         "scripts/test_movie_recorder_video_start_contract.py",
         "scripts/test_screen_recorder_start_stop_contract.py",
+        "scripts/run-python.sh",
+        "scripts/run-xcodebuild.sh",
         "CaptureSample/PersistenceController.swift",
         "CaptureSample/Views/MenuView.swift",
         "CaptureSample/CaptureSample.entitlements",
@@ -176,8 +178,6 @@ def project_checks():
     for fragment in (
         "override SHELL := /bin/sh",
         "override .SHELLFLAGS := -c",
-        "override PYTHON := python3",
-        "override XCODEBUILD := xcodebuild",
         "override PYTHONDONTWRITEBYTECODE := 1",
         "export PYTHONDONTWRITEBYTECODE",
         "$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)",
@@ -186,11 +186,15 @@ def project_checks():
         root_declaration,
         "export ROOT",
         "$(error repository Makefile path could not be resolved)",
-        '$(PYTHON) "$$ROOT/scripts/check-capture-source.py" --mode project',
-        '$(PYTHON) "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"',
-        '$(PYTHON) "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"',
-        '$(PYTHON) "$$ROOT/scripts/test_stream_delegate_failure_contract.py"',
-        'cd "$$ROOT" && $(XCODEBUILD) -project ScreenRecorder.xcodeproj',
+        "override PYTHON := $(ROOT)/scripts/run-python.sh",
+        "override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh",
+        "export PYTHON XCODEBUILD",
+        '"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode project',
+        '"$$PYTHON" "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"',
+        '"$$PYTHON" "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"',
+        '"$$PYTHON" "$$ROOT/scripts/test_stream_delegate_failure_contract.py"',
+        '[ -x /usr/bin/xcodebuild ]',
+        'cd "$$ROOT" && "$$XCODEBUILD" -project ScreenRecorder.xcodeproj',
         "CODE_SIGNING_ALLOWED=NO build",
         "root-test:",
         '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"',
@@ -198,6 +202,21 @@ def project_checks():
     ):
         if fragment not in makefile:
             errors.append(f"Makefile must keep contract: {fragment}")
+
+    expected_python_launcher = (
+        "#!/bin/sh\n"
+        "set -eu\n\n"
+        "exec /usr/bin/python3 -I -B -c 'import os, runpy, sys; script = sys.argv[1]; "
+        "sys.argv = sys.argv[1:]; sys.path.insert(0, os.path.dirname(os.path.realpath(script))); "
+        "runpy.run_path(script, run_name=\"__main__\")' \"$@\"\n"
+    )
+    if read_text("scripts/run-python.sh") != expected_python_launcher:
+        errors.append("scripts/run-python.sh must keep the absolute isolated Python launcher")
+    expected_xcode_launcher = (
+        "#!/bin/sh\nset -eu\n\nexec /usr/bin/xcodebuild \"$@\"\n"
+    )
+    if read_text("scripts/run-xcodebuild.sh") != expected_xcode_launcher:
+        errors.append("scripts/run-xcodebuild.sh must keep the absolute Xcode launcher")
 
     if MAKE_ROOT_PLAN.exists():
         root_plan = MAKE_ROOT_PLAN.read_text(encoding="utf-8")
@@ -220,9 +239,10 @@ def project_checks():
         root_test_text = root_test.read_text(encoding="utf-8")
         for evidence in (
             "66 executed target/authority cases",
+            "1 dollar-syntax checkout case",
             "MAKEFILE_LIST must not be overridden",
             "MAKEFILES must be empty",
-            "repository Makefile path could not be resolved",
+            "earlier-Makefile detection",
         ):
             if evidence not in root_test_text:
                 errors.append(f"{root_test.relative_to(ROOT)} must preserve {evidence!r}")
@@ -233,7 +253,7 @@ def project_checks():
         authority_plan = MAKE_AUTHORITY_PLAN.read_text(encoding="utf-8")
         for evidence in (
             "Status: Completed",
-            "`make root-test` passed 66 target/authority cases and four rejection cases",
+            "`make root-test` passed 66 target/authority cases, one dollar-syntax checkout case, three override rejections, and one earlier-file detection",
             "`make check` passed from the repository and through an absolute Makefile path",
         ):
             if evidence not in authority_plan:

--- a/scripts/run-python.sh
+++ b/scripts/run-python.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec /usr/bin/python3 -I -B -c 'import os, runpy, sys; script = sys.argv[1]; sys.argv = sys.argv[1:]; sys.path.insert(0, os.path.dirname(os.path.realpath(script))); runpy.run_path(script, run_name="__main__")' "$@"

--- a/scripts/run-xcodebuild.sh
+++ b/scripts/run-xcodebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec /usr/bin/xcodebuild "$@"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -12,6 +12,8 @@ CHECKOUT="$TEMP_ROOT/screen-recorder's [gate] \"quoted\" \`touch SCREEN_RECORDER
 COMMAND_LOG="$TEMP_ROOT/commands.log"
 BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
 FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
+PATH_SHADOW_LOG="$TEMP_ROOT/path-shadow.log"
+export SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG"
 mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
 CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
 CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
@@ -21,9 +23,16 @@ cp "$ROOT_DIR/Makefile" "$MAKEFILE"
 for command in python3 xcodebuild; do
   cat >"$CHECKOUT/bin/$command" <<'EOF'
 #!/bin/sh
-printf '%s|%s|%s|%s\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" "$*" >> "$SCREEN_RECORDER_COMMAND_LOG"
+printf '%s\n' invoked >> "$SCREEN_RECORDER_PATH_SHADOW_LOG"
 EOF
   chmod +x "$CHECKOUT/bin/$command"
+done
+for command in run-python.sh run-xcodebuild.sh; do
+  cat >"$CHECKOUT/scripts/$command" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|%s\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" "$*" >> "$SCREEN_RECORDER_COMMAND_LOG"
+EOF
+  chmod +x "$CHECKOUT/scripts/$command"
 done
 cat >"$CHECKOUT/scripts/test-makefile-root.sh" <<'EOF'
 #!/bin/sh
@@ -70,16 +79,16 @@ run_case() {
   scenario=$1
   target=$2
   mode=$3
-  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG"
+  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG" "$PATH_SHADOW_LOG"
   output="$TEMP_ROOT/output"
   set +e
   case "$mode" in
     default)
-      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
     command-root)
       (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "ROOT=$ATTACKER_ROOT" "$target") >"$output" 2>&1 ;;
     environment-root)
-      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ROOT="$ATTACKER_ROOT" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ROOT="$ATTACKER_ROOT" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
     command-shell)
       (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "SHELL=$FAKE_SHELL" "$target") >"$output" 2>&1 ;;
     environment-shell)
@@ -116,6 +125,10 @@ run_case() {
     printf '%s\n' "$scenario $target executed caller-controlled shell" >&2
     exit 1
   fi
+  if [ -e "$PATH_SHADOW_LOG" ]; then
+    printf '%s\n' "$scenario $target executed a PATH-shadowed Python or xcodebuild" >&2
+    exit 1
+  fi
 }
 
 for target in build check lint root-test test verify; do
@@ -131,6 +144,24 @@ for target in build check lint root-test test verify; do
   run_case command-xcodebuild "$target" command-xcodebuild
   run_case environment-xcodebuild "$target" environment-xcodebuild
 done
+
+DOLLAR_CHECKOUT="$TEMP_ROOT/screen-recorder \$(touch SCREEN_RECORDER_DOLLAR_MARKER)"
+mkdir "$DOLLAR_CHECKOUT" "$DOLLAR_CHECKOUT/scripts"
+DOLLAR_CHECKOUT=$(CDPATH= cd -- "$DOLLAR_CHECKOUT" && /bin/pwd -P)
+cp "$MAKEFILE" "$DOLLAR_CHECKOUT/Makefile"
+cp "$CHECKOUT/scripts/run-python.sh" "$DOLLAR_CHECKOUT/scripts/run-python.sh"
+rm -f "$COMMAND_LOG" "$PATH_SHADOW_LOG"
+(cd "$DOLLAR_CHECKOUT" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory lint) >"$TEMP_ROOT/dollar-path.out" 2>&1
+case "$(cat "$COMMAND_LOG")" in
+  "$DOLLAR_CHECKOUT|$DOLLAR_CHECKOUT/scripts/run-python.sh|1|"*) ;;
+  *)
+    printf '%s\n' "dollar-syntax checkout escaped repository-owned Python: $(cat "$COMMAND_LOG")" >&2
+    exit 1 ;;
+esac
+if [ -e "$DOLLAR_CHECKOUT/SCREEN_RECORDER_DOLLAR_MARKER" ] || [ -e "$PATH_SHADOW_LOG" ]; then
+  printf '%s\n' "dollar-syntax checkout executed command syntax or a PATH-shadowed tool" >&2
+  exit 1
+fi
 
 if [ -e "$CONTROL_DIR/SCREEN_RECORDER_BACKTICK_MARKER" ]; then
   printf '%s\n' "checkout path executed a command substitution" >&2
@@ -149,4 +180,4 @@ EARLIER="$TEMP_ROOT/earlier.mk"
 printf '%s\n' '# earlier' >"$EARLIER"
 if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
 grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
-printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 earlier-Makefile detection"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/screen-recorder-root-control-XXXXXX")
+ATTACKER_ROOT="$TEMP_ROOT/attacker-root"
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+unset MAKEFILES MAKEFILE_LIST MAKEFLAGS MFLAGS MAKEOVERRIDES ROOT PYTHON XCODEBUILD PYTHONDONTWRITEBYTECODE
+
+CONTROL_DIR="$TEMP_ROOT/control"
+CHECKOUT="$TEMP_ROOT/screen-recorder's [gate] \"quoted\" \`touch SCREEN_RECORDER_BACKTICK_MARKER\`"
+COMMAND_LOG="$TEMP_ROOT/commands.log"
+BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
+FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
+mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
+CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
+MAKEFILE="$CHECKOUT/Makefile"
+cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+
+for command in python3 xcodebuild; do
+  cat >"$CHECKOUT/bin/$command" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|%s\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" "$*" >> "$SCREEN_RECORDER_COMMAND_LOG"
+EOF
+  chmod +x "$CHECKOUT/bin/$command"
+done
+cat >"$CHECKOUT/scripts/test-makefile-root.sh" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|root-test\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" >> "$SCREEN_RECORDER_COMMAND_LOG"
+EOF
+chmod +x "$CHECKOUT/scripts/test-makefile-root.sh"
+
+BAD_COMMAND="$TEMP_ROOT/bad-command"
+cat >"$BAD_COMMAND" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$BAD_COMMAND_LOG'
+exit 91
+EOF
+chmod +x "$BAD_COMMAND"
+
+FAKE_SHELL="$TEMP_ROOT/fake-shell"
+cat >"$FAKE_SHELL" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$FAKE_SHELL_LOG'
+exec /bin/sh "\$@"
+EOF
+chmod +x "$FAKE_SHELL"
+
+assert_commands_stayed_in_checkout() {
+  scenario=$1
+  target=$2
+  if [ ! -s "$COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed no quality command" >&2
+    exit 1
+  fi
+  while IFS= read -r command; do
+    case "$command" in
+      "$CONTROL_DIR|"*"$CHECKOUT"*"|1|"*) ;;
+      "$CHECKOUT|"*"|1|"*) ;;
+      *)
+        printf '%s\n' "$scenario $target escaped the checkout or enabled bytecode: $command" >&2
+        exit 1
+        ;;
+    esac
+  done <"$COMMAND_LOG"
+}
+
+run_case() {
+  scenario=$1
+  target=$2
+  mode=$3
+  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG"
+  output="$TEMP_ROOT/output"
+  set +e
+  case "$mode" in
+    default)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "ROOT=$ATTACKER_ROOT" "$target") >"$output" 2>&1 ;;
+    environment-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ROOT="$ATTACKER_ROOT" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "SHELL=$FAKE_SHELL" "$target") >"$output" 2>&1 ;;
+    environment-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SHELL="$FAKE_SHELL" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-flags)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" '.SHELLFLAGS=-eu -c' "$target") >"$output" 2>&1 ;;
+    environment-flags)
+      (cd "$CONTROL_DIR" && env '.SHELLFLAGS=-eu -c' PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-python)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "PYTHON=$BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-python)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" PYTHON="$BAD_COMMAND" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-xcodebuild)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "XCODEBUILD=$BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-xcodebuild)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" XCODEBUILD="$BAD_COMMAND" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    *)
+      printf '%s\n' "unknown test mode: $mode" >&2
+      exit 1 ;;
+  esac
+  result=$?
+  set -e
+  if [ "$result" -ne 0 ]; then
+    printf '%s\n' "$scenario $target failed" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_commands_stayed_in_checkout "$scenario" "$target"
+  if [ -e "$BAD_COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled Python or xcodebuild" >&2
+    exit 1
+  fi
+  if [ -e "$FAKE_SHELL_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled shell" >&2
+    exit 1
+  fi
+}
+
+for target in build check lint root-test test verify; do
+  run_case default "$target" default
+  run_case command-root "$target" command-root
+  run_case environment-root "$target" environment-root
+  run_case command-shell "$target" command-shell
+  run_case environment-shell "$target" environment-shell
+  run_case command-flags "$target" command-flags
+  run_case environment-flags "$target" environment-flags
+  run_case command-python "$target" command-python
+  run_case environment-python "$target" environment-python
+  run_case command-xcodebuild "$target" command-xcodebuild
+  run_case environment-xcodebuild "$target" environment-xcodebuild
+done
+
+if [ -e "$CONTROL_DIR/SCREEN_RECORDER_BACKTICK_MARKER" ]; then
+  printf '%s\n' "checkout path executed a command substitution" >&2
+  exit 1
+fi
+
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/command-list.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/command-list.out"
+if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/environment-list.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/environment-list.out"
+PRELOADED="$TEMP_ROOT/preloaded.mk"
+printf '%s\n' 'ROOT := /tmp/preloaded' >"$PRELOADED"
+if (cd "$CONTROL_DIR" && MAKEFILES="$PRELOADED" /usr/bin/make --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/preloaded.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILES must be empty" "$TEMP_ROOT/preloaded.out"
+EARLIER="$TEMP_ROOT/earlier.mk"
+printf '%s\n' '# earlier' >"$EARLIER"
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
+grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"


### PR DESCRIPTION
## Summary

Harden repository verification so caller-controlled GNU Make inputs cannot preload arbitrary logic, replace the recipe shell, bypass Python contracts, substitute a no-op Xcode builder, redirect the checkout root, or re-enable Python bytecode.

## Baseline

The existing root guard stopped direct `ROOT=/tmp` redirection, but `PYTHON=/bin/true` could bypass static and behavior contracts and `XCODEBUILD=/bin/true` could make the native build target succeed without compiling. `MAKEFILES`, `MAKEFILE_LIST`, `SHELL`, `.SHELLFLAGS`, and bytecode settings also remained caller-controlled. The baseline `make check` left `__pycache__` artifacts behind.

## Improvements

### Tests

- Added `make root-test` with 66 public-target/authority cases and four explicit file-list, preload, and multiple-Makefile rejection cases.
- Simulates both Python and Xcode commands in a copied checkout whose path contains spaces, quotes, brackets, and command-substitution syntax.

### Security

- Fixes the repository-owned shell, shell flags, Python checker, and Xcode builder.
- Rejects `MAKEFILES` and overridden `MAKEFILE_LIST` before targets run.
- Safely derives and exports the exact repository root.
- Forces bytecode suppression so verification remains artifact-free.

### Documentation

- Documents the tightened authority and bytecode boundary in the README, change log, and completed maintenance plans.

## Validation

Passed on exact head `c590216a2c4be2b253f7ab9e770bc79fb0330400`:

- `make root-test`
- `make check`
- `make --no-print-directory --file /absolute/path/to/Makefile check` from an external directory
- Project and behavior source contracts
- 25 focused mutation cases across recorder start, stop, autostart, menu state, and stream cleanup contracts
- `python3 -B scripts/check-capture-source.py --mode project`
- `python3 -B scripts/check-capture-source.py --mode behavior`
- `/bin/sh -n scripts/test-makefile-root.sh`
- `git diff --check HEAD^ HEAD`
- `git fsck --strict`
- Gitleaks directory and exact commit-range scans with redacted output
- No `.pyc`, `__pycache__`, or DerivedData artifacts remain
- Follow-up commit `c590216a2c4be2b253f7ab9e770bc79fb0330400` adds repository-owned absolute Python/Xcode launchers, rejects PATH shadowing, and covers literal dollar-syntax checkout paths.

## Risk

- Linux validation cannot execute ScreenCaptureKit or Xcode; the existing macOS GitHub Actions build remains the native compile boundary.
- `PYTHON` and `XCODEBUILD` are intentionally no longer caller-configurable because they are trusted verification commands.
- Interactive screen-recording permission, runtime capture, audio/video output, and playback are not exercised by hosted CI.
- No Swift source, Xcode project, entitlements, signing settings, or application behavior changed.

## Follow-Ups

- Add an XCTest target for runtime-independent recorder state transitions when the project is next modernized.
- Keep interactive ScreenCaptureKit permission and output verification as a documented manual macOS test.

