### PR TITLE
fix: narrow ScreenRecorder Make authority boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PUBLIC_TARGETS := build check lint root-test test verify
 
 override SHELL := /bin/sh
 override .SHELLFLAGS := -c
+$(PUBLIC_TARGETS): override SHELL := /bin/sh
+$(PUBLIC_TARGETS): override .SHELLFLAGS := -c
 override PYTHONDONTWRITEBYTECODE := 1
 export PYTHONDONTWRITEBYTECODE
 ifneq ($(strip $(MAKEFILES)),)
@@ -21,29 +23,33 @@ endif
 override PYTHON := $(ROOT)/scripts/run-python.sh
 override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh
 export PYTHON XCODEBUILD
+override REPOSITORY_SHELL_LITERAL = $(subst $$,$$$$,$(subst ','"'"',$1))
+override REPOSITORY_ROOT_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(ROOT))
+override REPOSITORY_PYTHON_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(PYTHON))
+override REPOSITORY_XCODEBUILD_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(XCODEBUILD))
 
 $(PUBLIC_TARGETS)::
 
 lint::
-	"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode project
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/check-capture-source.py' --mode project
 
 test::
-	"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode behavior
-	"$$PYTHON" "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"
-	"$$PYTHON" "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"
-	"$$PYTHON" "$$ROOT/scripts/test_user_stopped_autostart_contract.py"
-	"$$PYTHON" "$$ROOT/scripts/test_menu_recorder_state_contract.py"
-	"$$PYTHON" "$$ROOT/scripts/test_stream_delegate_failure_contract.py"
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/check-capture-source.py' --mode behavior
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_movie_recorder_video_start_contract.py'
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_screen_recorder_start_stop_contract.py'
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_user_stopped_autostart_contract.py'
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_menu_recorder_state_contract.py'
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_stream_delegate_failure_contract.py'
 
 build:: lint
 	@if [ -x /usr/bin/xcodebuild ]; then \
-		cd "$$ROOT" && "$$XCODEBUILD" -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
+		cd '$(REPOSITORY_ROOT_LITERAL)' && '$(REPOSITORY_XCODEBUILD_LITERAL)' -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "xcodebuild not found; static project checks completed"; \
 	fi
 
 root-test::
-	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
+	/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'
 
 verify:: root-test lint test build
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build check lint root-test test verify
 
+PUBLIC_TARGETS := build check lint root-test test verify
+
 override SHELL := /bin/sh
 override .SHELLFLAGS := -c
 override PYTHONDONTWRITEBYTECODE := 1
@@ -20,10 +22,12 @@ override PYTHON := $(ROOT)/scripts/run-python.sh
 override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh
 export PYTHON XCODEBUILD
 
-lint:
+$(PUBLIC_TARGETS)::
+
+lint::
 	"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode project
 
-test:
+test::
 	"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode behavior
 	"$$PYTHON" "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"
 	"$$PYTHON" "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"
@@ -31,16 +35,16 @@ test:
 	"$$PYTHON" "$$ROOT/scripts/test_menu_recorder_state_contract.py"
 	"$$PYTHON" "$$ROOT/scripts/test_stream_delegate_failure_contract.py"
 
-build: lint
+build:: lint
 	@if [ -x /usr/bin/xcodebuild ]; then \
 		cd "$$ROOT" && "$$XCODEBUILD" -project ScreenRecorder.xcodeproj -scheme CaptureSample -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "xcodebuild not found; static project checks completed"; \
 	fi
 
-root-test:
+root-test::
 	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
 
-verify: root-test lint test build
+verify:: root-test lint test build
 
-check: verify
+check:: verify

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 override PYTHON := $(ROOT)/scripts/run-python.sh
 override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh
 export PYTHON XCODEBUILD
-override REPOSITORY_SHELL_LITERAL = $(subst $$,$$$$,$(subst ','"'"',$1))
+override REPOSITORY_SHELL_LITERAL = $(subst ','"'"',$1)
 override REPOSITORY_ROOT_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(ROOT))
 override REPOSITORY_PYTHON_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(PYTHON))
 override REPOSITORY_XCODEBUILD_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(XCODEBUILD))

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   shell, repository-owned isolated Python launcher, absolute Xcode launcher,
   and bytecode policy under repository control while detecting unsupported
   preload and Makefile-list inputs before repository recipes execute.
+  Later single-colon replacement of all six public aliases fails during Make
+  parsing. Arbitrary caller Make programs remain outside this local boundary:
+  GNU Make `override` directives, caller-added double-colon recipes, and
+  startup parse-time code can execute with Make-level authority.
   Standard in-checkout invocation supports literal dollar and command-syntax
   path characters; an absolute `--file` path containing `$` is unsupported
   because GNU Make expands it before `MAKEFILE_LIST` can expose the filename.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   Later single-colon replacement of all six public aliases fails during Make
   parsing. Arbitrary caller Make programs remain outside this local boundary:
   GNU Make `override` directives, caller-added double-colon recipes, and
-  startup parse-time code can execute with Make-level authority.
+  startup parse-time code can execute with Make-level authority. Repository
+  aliases pin `/bin/sh -c` target-specifically and embed the reviewed root and
+  launcher paths before later non-override target-specific variables can alter
+  recipe execution.
   Standard in-checkout invocation supports literal dollar and command-syntax
   path characters; an absolute `--file` path containing `$` is unsupported
   because GNU Make expands it before `MAKEFILE_LIST` can expose the filename.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -30,6 +30,9 @@ replace static contracts or turn the hosted native build into a no-op.
   file-list/preload rejection and earlier-file detection cases.
 - Defined all six public aliases as double-colon rules so later single-colon
   recipe replacement fails during parsing before an attacker recipe executes.
+- Pinned `/bin/sh -c` target-specifically and embedded the reviewed root,
+  isolated Python launcher, and absolute Xcode launcher in repository recipes
+  before later non-override target-specific variables can replace them.
 - Left Swift source, Xcode project, entitlements, and application behavior
   unchanged.
 

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -28,6 +28,8 @@ replace static contracts or turn the hosted native build into a no-op.
   command-substitution syntax in its path.
 - Covered all six public targets across eleven authority modes plus explicit
   file-list/preload rejection and earlier-file detection cases.
+- Defined all six public aliases as double-colon rules so later single-colon
+  recipe replacement fails during parsing before an attacker recipe executes.
 - Left Swift source, Xcode project, entitlements, and application behavior
   unchanged.
 
@@ -41,6 +43,11 @@ verification inputs. The repository detects the cases visible when its own
 file is parsed and fails before repository recipes execute; CI and documented
 usage invoke `make check` without extra startup code.
 
+This is a checked-in Makefile boundary, not a sandbox for arbitrary caller
+programs. GNU Make `override` directives, caller-added double-colon recipes,
+and startup parse-time code retain Make-level authority and remain outside the
+local no-execution claim.
+
 GNU Make also expands dollar syntax in an absolute `--file` argument before
 recording `MAKEFILE_LIST`. Repositories whose path contains `$` therefore use
 the documented in-checkout `make check` form; that form is covered with a
@@ -49,6 +56,8 @@ literal `$(...)` directory name and does not execute the path text.
 ## Verification
 
 - `make root-test` passed 66 target/authority cases, one dollar-syntax checkout case, three override rejections, and one earlier-file detection.
+- A later single-colon file replacing all six public aliases failed closed
+  before any replacement marker or repository recipe executed.
 - `make check` passed from the repository and through an absolute Makefile path.
 - Python and shell syntax checks, `git diff --check`, and repository integrity
   screening passed.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -178,6 +178,8 @@ def project_checks():
     for fragment in (
         "override SHELL := /bin/sh",
         "override .SHELLFLAGS := -c",
+        "$(PUBLIC_TARGETS): override SHELL := /bin/sh",
+        "$(PUBLIC_TARGETS): override .SHELLFLAGS := -c",
         "override PYTHONDONTWRITEBYTECODE := 1",
         "export PYTHONDONTWRITEBYTECODE",
         "$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)",
@@ -189,17 +191,20 @@ def project_checks():
         "override PYTHON := $(ROOT)/scripts/run-python.sh",
         "override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh",
         "export PYTHON XCODEBUILD",
+        "override REPOSITORY_ROOT_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(ROOT))",
+        "override REPOSITORY_PYTHON_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(PYTHON))",
+        "override REPOSITORY_XCODEBUILD_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(XCODEBUILD))",
         "PUBLIC_TARGETS := build check lint root-test test verify",
         "$(PUBLIC_TARGETS)::",
-        '"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode project',
-        '"$$PYTHON" "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"',
-        '"$$PYTHON" "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"',
-        '"$$PYTHON" "$$ROOT/scripts/test_stream_delegate_failure_contract.py"',
+        "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/check-capture-source.py' --mode project",
+        "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_movie_recorder_video_start_contract.py'",
+        "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_screen_recorder_start_stop_contract.py'",
+        "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_stream_delegate_failure_contract.py'",
         '[ -x /usr/bin/xcodebuild ]',
-        'cd "$$ROOT" && "$$XCODEBUILD" -project ScreenRecorder.xcodeproj',
+        "cd '$(REPOSITORY_ROOT_LITERAL)' && '$(REPOSITORY_XCODEBUILD_LITERAL)' -project ScreenRecorder.xcodeproj",
         "CODE_SIGNING_ALLOWED=NO build",
         "root-test::",
-        '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"',
+        "\t/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'",
         "verify:: root-test lint test build",
     ):
         if fragment not in makefile:
@@ -246,6 +251,7 @@ def project_checks():
             "MAKEFILES must be empty",
             "earlier-Makefile detection",
             "later six-recipe replacement rejection",
+            "later target-specific authority containment case",
             "documented override/double-colon caller boundaries",
         ):
             if evidence not in root_test_text:

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -189,6 +189,8 @@ def project_checks():
         "override PYTHON := $(ROOT)/scripts/run-python.sh",
         "override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh",
         "export PYTHON XCODEBUILD",
+        "PUBLIC_TARGETS := build check lint root-test test verify",
+        "$(PUBLIC_TARGETS)::",
         '"$$PYTHON" "$$ROOT/scripts/check-capture-source.py" --mode project',
         '"$$PYTHON" "$$ROOT/scripts/test_movie_recorder_video_start_contract.py"',
         '"$$PYTHON" "$$ROOT/scripts/test_screen_recorder_start_stop_contract.py"',
@@ -196,9 +198,9 @@ def project_checks():
         '[ -x /usr/bin/xcodebuild ]',
         'cd "$$ROOT" && "$$XCODEBUILD" -project ScreenRecorder.xcodeproj',
         "CODE_SIGNING_ALLOWED=NO build",
-        "root-test:",
+        "root-test::",
         '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"',
-        "verify: root-test lint test build",
+        "verify:: root-test lint test build",
     ):
         if fragment not in makefile:
             errors.append(f"Makefile must keep contract: {fragment}")
@@ -243,6 +245,8 @@ def project_checks():
             "MAKEFILE_LIST must not be overridden",
             "MAKEFILES must be empty",
             "earlier-Makefile detection",
+            "later six-recipe replacement rejection",
+            "documented override/double-colon caller boundaries",
         ):
             if evidence not in root_test_text:
                 errors.append(f"{root_test.relative_to(ROOT)} must preserve {evidence!r}")
@@ -255,11 +259,23 @@ def project_checks():
             "Status: Completed",
             "`make root-test` passed 66 target/authority cases, one dollar-syntax checkout case, three override rejections, and one earlier-file detection",
             "`make check` passed from the repository and through an absolute Makefile path",
+            "GNU Make `override` directives",
+            "caller-added double-colon recipes",
+            "startup parse-time code",
         ):
             if evidence not in authority_plan:
                 errors.append(
                     f"{MAKE_AUTHORITY_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
                 )
+
+    readme = read_text("README.md")
+    for evidence in (
+        "GNU Make `override` directives",
+        "caller-added double-colon recipes",
+        "startup parse-time code",
+    ):
+        if evidence not in readme:
+            errors.append(f"README.md must document caller Make boundary {evidence!r}")
 
     for docs_file in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         document = read_text(docs_file)

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
 TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/screen-recorder-root-control-XXXXXX")
 ATTACKER_ROOT="$TEMP_ROOT/attacker-root"
 trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
@@ -15,8 +15,8 @@ FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
 PATH_SHADOW_LOG="$TEMP_ROOT/path-shadow.log"
 export SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG"
 mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
-CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
-CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
+CONTROL_DIR=$(CDPATH='' cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH='' cd -- "$CHECKOUT" && /bin/pwd -P)
 MAKEFILE="$CHECKOUT/Makefile"
 cp "$ROOT_DIR/Makefile" "$MAKEFILE"
 
@@ -147,7 +147,7 @@ done
 
 DOLLAR_CHECKOUT="$TEMP_ROOT/screen-recorder \$(touch SCREEN_RECORDER_DOLLAR_MARKER)"
 mkdir "$DOLLAR_CHECKOUT" "$DOLLAR_CHECKOUT/scripts"
-DOLLAR_CHECKOUT=$(CDPATH= cd -- "$DOLLAR_CHECKOUT" && /bin/pwd -P)
+DOLLAR_CHECKOUT=$(CDPATH='' cd -- "$DOLLAR_CHECKOUT" && /bin/pwd -P)
 cp "$MAKEFILE" "$DOLLAR_CHECKOUT/Makefile"
 cp "$CHECKOUT/scripts/run-python.sh" "$DOLLAR_CHECKOUT/scripts/run-python.sh"
 rm -f "$COMMAND_LOG" "$PATH_SHADOW_LOG"
@@ -180,4 +180,29 @@ EARLIER="$TEMP_ROOT/earlier.mk"
 printf '%s\n' '# earlier' >"$EARLIER"
 if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
 grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
-printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 earlier-Makefile detection"
+
+LATER="$TEMP_ROOT/later.mk"
+LATER_MARKER="$TEMP_ROOT/later-marker"
+cat >"$LATER" <<EOF
+.PHONY: build check lint root-test test verify
+build check lint root-test test verify:
+	@printf '%s\n' '\$@' >> '$LATER_MARKER'
+EOF
+rm -f "$LATER_MARKER" "$COMMAND_LOG"
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER" check) >"$TEMP_ROOT/later.out" 2>&1; then
+  printf '%s\n' "later six-recipe replacement unexpectedly passed" >&2
+  exit 1
+fi
+if [ -e "$LATER_MARKER" ] || [ -e "$COMMAND_LOG" ]; then
+  printf '%s\n' "later six-recipe replacement reached a recipe" >&2
+  exit 1
+fi
+grep -Fq "has both : and :: entries" "$TEMP_ROOT/later.out"
+
+BOUNDARY_TEXT="GNU Make \`override\` directives"
+grep -Fq "$BOUNDARY_TEXT" "$ROOT_DIR/README.md"
+grep -Fq 'caller-added double-colon recipes' "$ROOT_DIR/README.md"
+grep -Fq "$BOUNDARY_TEXT" "$ROOT_DIR/docs/plans/2026-06-21-make-authority-isolation.md"
+grep -Fq 'caller-added double-colon recipes' "$ROOT_DIR/docs/plans/2026-06-21-make-authority-isolation.md"
+
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, 1 earlier-Makefile detection, 1 later six-recipe replacement rejection, and documented override/double-colon caller boundaries"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -208,7 +208,10 @@ build check lint root-test test verify: SHELL := $FAKE_SHELL
 build check lint root-test test verify: .SHELLFLAGS := -c
 EOF
 rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG" "$PATH_SHADOW_LOG"
-(cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER_VARS" lint) >"$TEMP_ROOT/later-vars.out" 2>&1
+if ! (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER_VARS" lint) >"$TEMP_ROOT/later-vars.out" 2>&1; then
+  cat "$TEMP_ROOT/later-vars.out" >&2
+  exit 1
+fi
 assert_commands_stayed_in_checkout later-target-variables lint
 if [ -e "$BAD_COMMAND_LOG" ] || [ -e "$FAKE_SHELL_LOG" ] || [ -e "$PATH_SHADOW_LOG" ]; then
   printf '%s\n' "later target-specific authority intercepted repository validation" >&2

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -199,10 +199,26 @@ if [ -e "$LATER_MARKER" ] || [ -e "$COMMAND_LOG" ]; then
 fi
 grep -Fq "has both : and :: entries" "$TEMP_ROOT/later.out"
 
+LATER_VARS="$TEMP_ROOT/later-vars.mk"
+cat >"$LATER_VARS" <<EOF
+build check lint root-test test verify: ROOT := $ATTACKER_ROOT
+build check lint root-test test verify: PYTHON := $BAD_COMMAND
+build check lint root-test test verify: XCODEBUILD := $BAD_COMMAND
+build check lint root-test test verify: SHELL := $FAKE_SHELL
+build check lint root-test test verify: .SHELLFLAGS := -c
+EOF
+rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG" "$PATH_SHADOW_LOG"
+(cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREEN_RECORDER_COMMAND_LOG="$COMMAND_LOG" SCREEN_RECORDER_PATH_SHADOW_LOG="$PATH_SHADOW_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER_VARS" lint) >"$TEMP_ROOT/later-vars.out" 2>&1
+assert_commands_stayed_in_checkout later-target-variables lint
+if [ -e "$BAD_COMMAND_LOG" ] || [ -e "$FAKE_SHELL_LOG" ] || [ -e "$PATH_SHADOW_LOG" ]; then
+  printf '%s\n' "later target-specific authority intercepted repository validation" >&2
+  exit 1
+fi
+
 BOUNDARY_TEXT="GNU Make \`override\` directives"
 grep -Fq "$BOUNDARY_TEXT" "$ROOT_DIR/README.md"
 grep -Fq 'caller-added double-colon recipes' "$ROOT_DIR/README.md"
 grep -Fq "$BOUNDARY_TEXT" "$ROOT_DIR/docs/plans/2026-06-21-make-authority-isolation.md"
 grep -Fq 'caller-added double-colon recipes' "$ROOT_DIR/docs/plans/2026-06-21-make-authority-isolation.md"
 
-printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, 1 earlier-Makefile detection, 1 later six-recipe replacement rejection, and documented override/double-colon caller boundaries"
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, 1 earlier-Makefile detection, 1 later six-recipe replacement rejection, 1 later target-specific authority containment case, and documented override/double-colon caller boundaries"


### PR DESCRIPTION
## Summary

Publishes the approved ScreenRecorderMacOS Make authority safeguard candidate for hosted validation.

## Baseline

The default branch already protects repository-owned verification entry points, but a later makefile could replace all six public single-colon recipes. This candidate narrows that authority boundary while documenting the caller-controlled cases that intentionally remain.

## Improvements

- Rejects a later six-recipe replacement for `build`, `check`, `lint`, `root-test`, `test`, and `verify` before any recipe executes.
- Documents that GNU Make `override` directives, caller-added double-colon recipes, startup parse-time code, and trusted tool resolution remain caller authority.
- Extends project checks and the root authority harness without changing app source, the Xcode project, workflows, or native launcher scripts.

## Validation

- Candidate head: `b92a933e4c96ddeb4200cacb74e6b2924644e8e2`
- Candidate tree: `febc8019187b1c0f178621dd54d2caec86d6fa05`
- Parent/default at publish time: `1e1ca3a14e8bbc4c263f8c9f4cce903b2ab2cc52`
- The later six-alias replacement attack fails closed under GNU Make 3.81 and GNU Make 4.3.
- Root authority harness passed `66` target/authority cases plus the file-list, preload, earlier-file, and later-replacement controls.
- Behavior/project mutation contracts passed with `25` rejected mutations.
- Real Xcode `26.0.1` build passed for `ScreenRecorder.xcodeproj` / `CaptureSample` with `CODE_SIGNING_ALLOWED=NO`.
- Xcode project parsing confirmed target `ScreenRecorder` and scheme `CaptureSample`.
- All hosted pull-request checks are green, including contract, macOS build, and CodeQL analyses.

## Risk

The change intentionally does not claim control over GNU Make `override` directives, caller-added double-colon recipes, startup parse-time code, or caller-controlled PATH/tool resolution. App behavior and native project files are unchanged.

## Follow-Ups

Auto-merge remains intentionally disabled. No approval or merge is requested by this metadata update.
