### PR TITLE
fix: reconcile refreshed capture sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ built with ScreenCaptureKit.
   recording cleanup path.
 - MovieRecorder exposes only its video transform at initialization; fixed audio
   and video output settings remain inside startRecording.
+- Reconcile refreshed displays by `displayID` and windows by `windowID`; object
+  instance refreshes must not trigger capture reconfiguration when IDs match.
 - See `docs/plans/2026-06-08-local-player-viewer.md` for the local player viewer guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,12 @@ stale selected capture sources.
 - Python compilation and `git diff --check` — passed.
 - Validation-created Python bytecode was removed; credential, recording-file,
   conflict-marker, and generated-artifact scans were clean.
-- Hosted build and exact-head review remain pending.
+- Initial exact-head Codex review — clean on
+  `7d621210ef28f5b495a600b16e394ea1ea8d7118` with no actionable findings.
+- Initial hosted contract and unsigned macOS build jobs — passed for push and
+  pull-request events; CodeQL Actions and Python passed while Swift analysis
+  remained in progress when this evidence update was prepared.
+- Final exact-head review and hosted reruns remain required after this update.
 
 ### Bugs / findings
 
@@ -57,7 +62,7 @@ stale selected capture sources.
 
 ### Next action
 
-- Complete hosted compilation and exact-head review.
+- Require clean final-head review plus hosted contract, build, and CodeQL gates.
 
 ## 2026-06-21
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,64 @@
 # Changes
 
+## 2026-06-25 12:43 PDT - P1 - Reconcile disconnected capture sources
+
+### Summary
+
+Replaced nil-only display/window selection refresh with stable-identifier
+reconciliation so disconnected displays and closed windows cannot remain as
+stale selected capture sources.
+
+### Work completed
+
+- Added a generic refreshed-selection helper keyed by `displayID` or `windowID`.
+- Replaced missing sources with the first current source while retaining the
+  refreshed object for unchanged IDs.
+- Prevented equivalent refreshed objects from triggering redundant active
+  capture configuration updates.
+- Added a focused mutation-sensitive source contract and maintenance plan.
+
+### Threads
+
+- Started: none; the focused source lifecycle defect was handled directly.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+
+- `CaptureSample/ScreenRecorder.swift` — reconciled refreshed source selection.
+- `scripts/capture_source_reconciliation_contract.py` — added source invariant.
+- `scripts/test_capture_source_reconciliation_contract.py` — added six hostile
+  mutations.
+- `Makefile` and `scripts/check-capture-source.py` — registered the new gate.
+- `README.md`, `VISION.md`, `AGENTS.md`, and the maintenance plan — documented
+  the lifecycle boundary.
+
+### Validation
+
+- Initial focused contract — rejected ten missing reconciliation invariants.
+- Focused mutation suite — passed with six hostile mutations rejected.
+- Repository and external-directory `make check` — passed 66 Make authority
+  cases plus all project, behavior, and mutation contracts; Linux truthfully
+  skipped unavailable Xcode.
+- Python compilation and `git diff --check` — passed.
+- Validation-created Python bytecode was removed; credential, recording-file,
+  conflict-marker, and generated-artifact scans were clean.
+- Hosted build and exact-head review remain pending.
+
+### Bugs / findings
+
+- P1: a disconnected display or closed selected window remained selected after
+  ScreenCaptureKit returned a new inventory.
+
+### Blockers
+
+- Live source-disconnect recording requires permission-capable macOS manual
+  validation; unsigned hosted compilation cannot exercise ScreenCaptureKit.
+
+### Next action
+
+- Complete hosted compilation and exact-head review.
+
 ## 2026-06-21
 
 - Isolated repository recipes from caller-controlled roots, shells, tool

--- a/CaptureSample/ScreenRecorder.swift
+++ b/CaptureSample/ScreenRecorder.swift
@@ -18,6 +18,16 @@ class AudioLevelsProvider: ObservableObject {
     @Published var audioLevels = AudioLevels.zero
 }
 
+private func refreshedSelection<Element, Identifier: Equatable>(
+    current: Element?,
+    available: [Element],
+    identifier: (Element) -> Identifier
+) -> Element? {
+    guard let current else { return available.first }
+    let currentIdentifier = identifier(current)
+    return available.first { identifier($0) == currentIdentifier } ?? available.first
+}
+
 @MainActor
 class ScreenRecorder: ObservableObject {
     
@@ -45,11 +55,15 @@ class ScreenRecorder: ObservableObject {
     }
     
     @Published var selectedDisplay: SCDisplay? {
-        didSet { updateEngine() }
+        didSet {
+            if oldValue?.displayID != selectedDisplay?.displayID { updateEngine() }
+        }
     }
     
     @Published var selectedWindow: SCWindow? {
-        didSet { updateEngine() }
+        didSet {
+            if oldValue?.windowID != selectedWindow?.windowID { updateEngine() }
+        }
     }
     
     @Published var isAppExcluded = true {
@@ -295,13 +309,17 @@ class ScreenRecorder: ObservableObject {
                 availableWindows = windows
             }
             availableApps = availableContent.applications
-            
-            if selectedDisplay == nil {
-                selectedDisplay = availableDisplays.first
-            }
-            if selectedWindow == nil {
-                selectedWindow = availableWindows.first
-            }
+
+            selectedDisplay = refreshedSelection(
+                current: selectedDisplay,
+                available: availableDisplays,
+                identifier: { $0.displayID }
+            )
+            selectedWindow = refreshedSelection(
+                current: selectedWindow,
+                available: availableWindows,
+                identifier: { $0.windowID }
+            )
         } catch {
             logger.error("Failed to get the shareable content: \(error.localizedDescription)")
         }

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test::
 	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_user_stopped_autostart_contract.py'
 	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_menu_recorder_state_contract.py'
 	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_stream_delegate_failure_contract.py'
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_capture_source_reconciliation_contract.py'
 
 build:: lint
 	@if [ -x /usr/bin/xcodebuild ]; then \

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   recorder's centralized timer string, with the visible timer reset after stop.
 - Static behavior checks also require recording start failures to stop audio
   metering and reset the visible timer.
+- Refreshed ScreenCaptureKit inventories replace disconnected display and
+  closed-window selections by stable source identifier, without reconfiguring
+  capture merely because an equivalent source object was refreshed.
 - Static behavior checks also require capture setup failures to cancel the
   movie writer and remove its unfinished file.
 - A writer startup failure propagates before ScreenCaptureKit starts, so the app
@@ -183,6 +186,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   menu start/stop and persisted-intent ordering contract.
 - See `docs/plans/2026-06-17-stream-delegate-failure-cleanup.md` for unexpected
   stream-stop routing through shared recording cleanup.
+- See `docs/plans/2026-06-25-capture-source-reconciliation.md` for display
+  disconnect and closed-window selection recovery.
 - See `docs/plans/2026-06-13-audio-sample-forwarding.md` for the recorded-audio
   output contract.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the

--- a/VISION.md
+++ b/VISION.md
@@ -51,7 +51,7 @@ Priority:
 Next priorities:
 
 - Add setup notes for macOS and Xcode requirements
-- Handle sleep, display disconnect, and writer failure cases gracefully
+- Handle sleep and additional writer failure cases gracefully
 - Add a configuration/viewing pane without hiding recording state
 
 Contribution rules:

--- a/docs/plans/2026-06-25-capture-source-reconciliation.md
+++ b/docs/plans/2026-06-25-capture-source-reconciliation.md
@@ -50,5 +50,5 @@ available source instead of retaining a disconnected display or closed window.
   display/window reconciliation, first-source fallback, and nil-only behavior.
 - repository and external-directory `make check` passed all portable project,
   behavior, mutation, and Make-authority gates; Linux truthfully skipped Xcode.
-- hosted unsigned macOS compilation remains required before merge.
+- hosted unsigned macOS compilation passed before merge.
 - Exact-head review evidence is recorded in `CHANGES.md` before merge.

--- a/docs/plans/2026-06-25-capture-source-reconciliation.md
+++ b/docs/plans/2026-06-25-capture-source-reconciliation.md
@@ -1,0 +1,54 @@
+# Capture Source Reconciliation
+
+Status: Completed
+
+## Context
+
+`refreshAvailableContent()` only selected the first display or window when the
+current selection was `nil`. If a selected display disconnected or a selected
+window closed, the model retained an object that was no longer present in the
+latest ScreenCaptureKit inventory. The picker could have no represented
+selection and later capture configuration could continue from stale source
+state.
+
+## Priority
+
+P1 capture-source correctness. A disappearing source must move selection to an
+available source instead of retaining a disconnected display or closed window.
+
+## Requirements
+
+- Match refreshed displays by `displayID` and windows by `windowID`.
+- Replace a missing selection with the first currently available source.
+- Refresh the selected object when the stable identifier remains available.
+- Avoid reconfiguring active capture when only the object instance refreshes
+  and its stable identifier is unchanged.
+- Preserve existing capture type, permission, recording, audio, timer,
+  persistence, and failure-cleanup behavior.
+- Add mutation-sensitive dependency-free contracts.
+
+## Verification
+
+- Prove the pre-fix source fails the focused reconciliation contract.
+- Reject mutations for both identifier guards, both source refreshes, first
+  source fallback, and restored nil-only behavior.
+- Run root and external-directory `make check`.
+- Require hosted unsigned macOS compilation and exact-head Codex review before
+  merge.
+
+## Risks
+
+- Permission-capable live display disconnect and window-close behavior cannot
+  run on this Linux host or in an unsigned hosted build.
+- ScreenCaptureKit may return refreshed object instances for an unchanged
+  source; stable-ID guards must prevent unnecessary stream updates.
+
+## Verification Completed
+
+- The pre-fix source failed the focused contract with ten missing invariants.
+- six capture-source mutations were rejected for display/window identity guards,
+  display/window reconciliation, first-source fallback, and nil-only behavior.
+- repository and external-directory `make check` passed all portable project,
+  behavior, mutation, and Make-authority gates; Linux truthfully skipped Xcode.
+- hosted unsigned macOS compilation remains required before merge.
+- Exact-head review evidence is recorded in `CHANGES.md` before merge.

--- a/scripts/capture_source_reconciliation_contract.py
+++ b/scripts/capture_source_reconciliation_contract.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+
+def validation_errors(source):
+    errors = []
+
+    helper_fragments = [
+        "private func refreshedSelection<Element, Identifier: Equatable>(",
+        "guard let current else { return available.first }",
+        "let currentIdentifier = identifier(current)",
+        "return available.first { identifier($0) == currentIdentifier } ?? available.first",
+    ]
+    for fragment in helper_fragments:
+        if fragment not in source:
+            errors.append(f"capture source reconciliation must preserve {fragment}")
+
+    property_fragments = [
+        "if oldValue?.displayID != selectedDisplay?.displayID { updateEngine() }",
+        "if oldValue?.windowID != selectedWindow?.windowID { updateEngine() }",
+    ]
+    for fragment in property_fragments:
+        if fragment not in source:
+            errors.append(f"capture source identity changes must preserve {fragment}")
+
+    refresh_fragments = [
+        "selectedDisplay = refreshedSelection(\n"
+        "                current: selectedDisplay,\n"
+        "                available: availableDisplays,\n"
+        "                identifier: { $0.displayID }\n"
+        "            )",
+        "selectedWindow = refreshedSelection(\n"
+        "                current: selectedWindow,\n"
+        "                available: availableWindows,\n"
+        "                identifier: { $0.windowID }\n"
+        "            )",
+    ]
+    for fragment in refresh_fragments:
+        if fragment not in source:
+            errors.append("capture refresh must replace missing or stale selected sources by stable identifier")
+
+    for stale_pattern in [
+        "if selectedDisplay == nil {",
+        "if selectedWindow == nil {",
+    ]:
+        if stale_pattern in source:
+            errors.append(f"capture refresh must not retain nil-only reconciliation: {stale_pattern}")
+
+    return errors

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -8,6 +8,7 @@ from menu_recorder_state_contract import validation_errors as menu_state_errors
 from movie_recorder_video_start_contract import validation_errors as video_start_errors
 from screen_recorder_start_stop_contract import validation_errors as start_stop_errors
 from stream_delegate_failure_contract import validation_errors as stream_delegate_errors
+from capture_source_reconciliation_contract import validation_errors as source_reconciliation_errors
 from user_stopped_autostart_contract import validation_errors as autostart_errors
 
 
@@ -31,6 +32,7 @@ RECORDER_SETTINGS_PLAN = DOCS_PLANS / "2026-06-16-recorder-settings-contract.md"
 USER_STOPPED_AUTOSTART_PLAN = DOCS_PLANS / "2026-06-16-user-stopped-autostart-guard.md"
 MENU_RECORDER_STATE_PLAN = DOCS_PLANS / "2026-06-16-menu-recorder-state-toggle.md"
 STREAM_DELEGATE_FAILURE_PLAN = DOCS_PLANS / "2026-06-17-stream-delegate-failure-cleanup.md"
+SOURCE_RECONCILIATION_PLAN = DOCS_PLANS / "2026-06-25-capture-source-reconciliation.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -61,8 +63,11 @@ def require_paths():
         str(USER_STOPPED_AUTOSTART_PLAN.relative_to(ROOT)),
         str(MENU_RECORDER_STATE_PLAN.relative_to(ROOT)),
         str(STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)),
+        str(SOURCE_RECONCILIATION_PLAN.relative_to(ROOT)),
         "scripts/test_movie_recorder_video_start_contract.py",
         "scripts/test_screen_recorder_start_stop_contract.py",
+        "scripts/capture_source_reconciliation_contract.py",
+        "scripts/test_capture_source_reconciliation_contract.py",
         "scripts/run-python.sh",
         "scripts/run-xcodebuild.sh",
         "CaptureSample/PersistenceController.swift",
@@ -200,6 +205,7 @@ def project_checks():
         "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_movie_recorder_video_start_contract.py'",
         "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_screen_recorder_start_stop_contract.py'",
         "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_stream_delegate_failure_contract.py'",
+        "'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_capture_source_reconciliation_contract.py'",
         '[ -x /usr/bin/xcodebuild ]',
         "cd '$(REPOSITORY_ROOT_LITERAL)' && '$(REPOSITORY_XCODEBUILD_LITERAL)' -project ScreenRecorder.xcodeproj",
         "CODE_SIGNING_ALLOWED=NO build",
@@ -330,6 +336,7 @@ def behavior_checks():
     errors.extend(stream_delegate_errors(capture_engine))
     screen_recorder = read_text("CaptureSample/ScreenRecorder.swift")
     errors.extend(start_stop_errors(screen_recorder))
+    errors.extend(source_reconciliation_errors(screen_recorder))
     capture_app = read_text("CaptureSample/CaptureSampleApp.swift")
     content_view = read_text("CaptureSample/ContentView.swift")
     errors.extend(autostart_errors(content_view))
@@ -646,6 +653,22 @@ def behavior_checks():
         if str(STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)) not in read_text("README.md"):
             errors.append(
                 f"README.md must reference {STREAM_DELEGATE_FAILURE_PLAN.relative_to(ROOT)}"
+            )
+    if SOURCE_RECONCILIATION_PLAN.exists():
+        source_reconciliation_plan = SOURCE_RECONCILIATION_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "six capture-source mutations were rejected",
+            "hosted unsigned macOS compilation",
+        ):
+            if evidence not in source_reconciliation_plan:
+                errors.append(
+                    f"{SOURCE_RECONCILIATION_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+        if str(SOURCE_RECONCILIATION_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+            errors.append(
+                f"README.md must reference {SOURCE_RECONCILIATION_PLAN.relative_to(ROOT)}"
             )
     if '@AppStorage("timerString")' in capture_app:
         errors.append("CaptureSampleApp must not keep a separate menu bar timer string")

--- a/scripts/test_capture_source_reconciliation_contract.py
+++ b/scripts/test_capture_source_reconciliation_contract.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from capture_source_reconciliation_contract import validation_errors
+
+
+ROOT = Path(__file__).resolve().parents[1]
+baseline = (ROOT / "CaptureSample" / "ScreenRecorder.swift").read_text(encoding="utf-8")
+
+errors = validation_errors(baseline)
+if errors:
+    raise AssertionError(f"baseline capture source reconciliation invalid: {errors}")
+
+mutations = {
+    "display identity guard removed": baseline.replace(
+        "if oldValue?.displayID != selectedDisplay?.displayID { updateEngine() }",
+        "updateEngine()",
+        1,
+    ),
+    "window identity guard removed": baseline.replace(
+        "if oldValue?.windowID != selectedWindow?.windowID { updateEngine() }",
+        "updateEngine()",
+        1,
+    ),
+    "display reconciliation removed": baseline.replace(
+        "            selectedDisplay = refreshedSelection(\n"
+        "                current: selectedDisplay,\n"
+        "                available: availableDisplays,\n"
+        "                identifier: { $0.displayID }\n"
+        "            )\n",
+        "",
+        1,
+    ),
+    "window reconciliation removed": baseline.replace(
+        "            selectedWindow = refreshedSelection(\n"
+        "                current: selectedWindow,\n"
+        "                available: availableWindows,\n"
+        "                identifier: { $0.windowID }\n"
+        "            )\n",
+        "",
+        1,
+    ),
+    "first-source fallback removed": baseline.replace(
+        "return available.first { identifier($0) == currentIdentifier } ?? available.first",
+        "return available.first { identifier($0) == currentIdentifier }",
+        1,
+    ),
+    "nil-only display reconciliation restored": baseline.replace(
+        "            selectedDisplay = refreshedSelection(\n"
+        "                current: selectedDisplay,\n"
+        "                available: availableDisplays,\n"
+        "                identifier: { $0.displayID }\n"
+        "            )\n",
+        "            if selectedDisplay == nil {\n"
+        "                selectedDisplay = availableDisplays.first\n"
+        "            }\n",
+        1,
+    ),
+}
+
+for description, source in mutations.items():
+    if not validation_errors(source):
+        raise AssertionError(f"{description} mutation was accepted")
+
+print(f"Capture source reconciliation contract passed ({len(mutations)} mutations rejected).")


### PR DESCRIPTION
## Summary
- reconcile refreshed displays by `displayID` and windows by `windowID`
- fall back to the first available source when the selected source disappears
- refresh equivalent source objects without redundant capture reconfiguration
- add a six-mutation static regression contract and lifecycle documentation

## Local verification
- focused reconciliation contract: six mutations rejected
- root and external-directory `make check`
- 66 Make authority cases plus all project/behavior contracts
- Python compilation, exact diff, artifact, credential, and recording-file scans

## Runtime boundary
- local Linux cannot execute ScreenCaptureKit or Xcode
- hosted unsigned macOS compilation is required before merge
