### PR TITLE
Document ScreenRecorder macOS setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,73 @@
 # Changes
 
+## 2026-06-26 03:24 PDT - P2 - Document supported recorder setup
+
+### Summary
+
+Completed the ScreenRecorder macOS/Xcode setup priority with source-backed
+guidance for the supported toolchain, Screen Recording authorization,
+automatic-start behavior, capture controls, local output, and verification.
+
+### Work completed
+
+- Replaced generic generated setup text with the shared scheme, destination,
+  signing, authorization, control, and local-persistence boundaries.
+- Documented the inherited camera entitlement versus the active
+  ScreenCaptureKit screen/system-audio path.
+- Added fail-closed guide, roadmap, history, and completed-plan contracts.
+
+### Threads
+
+- Started: none; the bounded documentation reconciliation was handled directly.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+
+- `README.md` — added the operational setup and manual-verification guide.
+- `VISION.md` — retired only the completed setup priority.
+- `scripts/check-capture-source.py` — added fail-closed guide contracts.
+- `docs/plans/2026-06-26-screen-recorder-setup-guide.md` — recorded the plan.
+- `CHANGES.md` — recorded this cycle and validation evidence.
+
+### Validation
+
+- Initial project checker — failed on the missing guide, roadmap, and history
+  contracts as expected.
+- Focused project checker — passed after the guide reconciliation.
+- Hostile setup-guide suite — rejected all 23 isolated README, roadmap,
+  history, and completed-plan mutations.
+- Two preliminary mutation-harness runs stopped before case 7 because the
+  wrapped System Settings Markdown phrase did not match the fixture; correcting
+  the fixture changed no repository file, and the complete rerun passed.
+- Checkout and external-directory `/usr/bin/make check` — each passed 66 Make
+  target/authority cases, project and behavior checks, and 31 existing focused
+  recording mutations. Linux truthfully skipped unavailable Xcode.
+- Source audit — matched every guide claim to the project deployment/signing
+  settings, shared scheme, ScreenCaptureKit authorization and configuration,
+  persisted stop intent, Documents/Core Data output, and pinned workflow.
+- API scan — found no camera API, ScreenCaptureKit microphone-enable, network,
+  sharing, or export path in `CaptureSample`.
+- `git diff --check` — passed; the change is limited to documentation, its
+  static contract, and the completed plan.
+- Hosted build, CodeQL, and exact-head review remain pending until the PR head
+  is available.
+
+### Bugs / findings
+
+- P2: the previous README did not identify the macOS 13 target, shared scheme,
+  Screen Recording denial behavior, automatic recording start, or local output.
+
+### Blockers
+
+- Live authorization, source enumeration, capture, audio, and playback require
+  an authorized Mac and cannot be demonstrated by portable static checks.
+
+### Next action
+
+- Require exact-head hosted contract/build and CodeQL before merge, then run
+  the same checks on the merge commit.
+
 ## 2026-06-25 12:43 PDT - P1 - Reconcile disconnected capture sources
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -36,26 +36,80 @@ Additional scan context:
 
 ## Getting Started
 
-### Prerequisites
+### Supported macOS and Xcode Baseline
 
 - Git
-- macOS with Xcode for building Apple platform projects
+- macOS with Xcode and the macOS 13 SDK or newer
 - Python 3 for repository source checks
+- Swift 5 with a macOS 13 deployment target, as pinned in the Xcode project
 
 ### Setup
 
 ```bash
 git clone https://github.com/garethpaul/ScreenRecorderMacOS.git
 cd ScreenRecorderMacOS
+open ScreenRecorder.xcodeproj
 ```
 
-The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
+Select the shared `CaptureSample` scheme and the `My Mac` destination. The
+project intentionally leaves `DEVELOPMENT_TEAM` empty; command-line verification
+disables signing, while an interactive run may require a local team under the
+workstation's signing policy.
+
+### Screen Recording Permission
+
+The current capture path uses ScreenCaptureKit. On first appearance,
+`SCShareableContent` checks whether Screen Recording access is available. If it
+is denied, the app displays `No screen recording permission.`, disables its
+configuration controls, and points to **System Settings > Privacy & Security >
+Screen Recording**. Grant access there and relaunch the app if macOS requests
+it.
+
+The checked-in entitlement file includes a camera entitlement inherited from
+the sample, but the current source does not use camera APIs. Its stream
+configuration can capture screen/system audio and does not enable
+ScreenCaptureKit microphone capture.
+
+### Automatic Start Boundary
+
+After authorization, the main window starts capture automatically unless the
+persisted `userStopped` flag records an earlier explicit stop. Use the visible
+Start and Stop controls or the menu-bar control to change that intent; the menu
+bar timer reflects the recorder's actual state.
+
+### Capture Source and Audio Controls
+
+- Choose **Display** or **Window**, then select a current ScreenCaptureKit source.
+- **Exclude sample app from stream** removes this app from display capture.
+- **Capture audio** controls ScreenCaptureKit system-audio capture.
+- **Exclude app audio** omits this app's audio when the app remains in the stream.
+- While capture is running, source and audio changes update the active stream;
+  Start is disabled until Stop completes.
+
+### Local Recording Boundary
+
+Each successful session writes a UUID-named `.MOV` file in the user's
+Documents directory. After the asset writer finishes successfully, the app
+stores Core Data metadata containing the file URL and start/end times, lists
+that history, and plays the latest local recording. Failed or cancelled output
+is removed before metadata is saved. The current UI has no upload, sharing,
+export, or delete workflow.
 
 ## Running or Using the Project
 
-- Open `ScreenRecorder.xcodeproj` in Xcode, choose the app or sample scheme, and run it on the matching simulator/device.
+- Run the shared `CaptureSample` scheme on `My Mac`, authorize Screen Recording,
+  choose a display or window, configure audio/exclusion options, and use Start
+  or Stop while watching the preview and menu-bar timer.
 
 ## Testing and Verification
+
+### Canonical Verification
+
+Run:
+
+```sh
+/usr/bin/make check
+```
 
 - `make check` runs static project/source checks. When `xcodebuild` is
   installed, the `build` target also runs the shared Xcode scheme with code
@@ -80,6 +134,14 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   persistence, and a timeout.
 - A second hosted job performs an unsigned app build on the fixed `macos-15`
   runner, so current Xcode compilation is enforced rather than inferred.
+
+### Hosted Native Verification
+
+The hosted unsigned build proves that the shared scheme compiles on
+`macos-15`. It does not grant Screen Recording permission, enumerate a user's
+real displays/windows, capture protected content, record system audio, or prove
+the local `.MOV` playback flow. Complete those checks manually on an authorized
+Mac with synthetic, non-sensitive content.
 - Static behavior checks cover capture crash paths, recording file URL
   creation, saved URL persistence, empty playback history handling, and
   prevention of hardcoded remote player URLs.

--- a/VISION.md
+++ b/VISION.md
@@ -46,11 +46,12 @@ Priority:
 - Keep completed maintenance plans under `docs/plans`
 - Keep GitHub Actions running the static `make check` baseline before review
 - Keep the unsigned app compiling on a fixed hosted macOS runner
+- Keep macOS/Xcode setup, Screen Recording permission, automatic-start, and
+  local-output guidance synchronized with source
 - Maintain README notes for known recording bugs
 
 Next priorities:
 
-- Add setup notes for macOS and Xcode requirements
 - Handle sleep and additional writer failure cases gracefully
 - Add a configuration/viewing pane without hiding recording state
 

--- a/docs/plans/2026-06-26-screen-recorder-setup-guide.md
+++ b/docs/plans/2026-06-26-screen-recorder-setup-guide.md
@@ -1,0 +1,107 @@
+# ScreenRecorder macOS Setup Guide Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Document ScreenRecorder's supported macOS and Xcode setup, Screen Recording permission, automatic-start behavior, capture controls, local output, and verification boundaries from checked-in source.
+
+**Architecture:** Preserve the Swift 5/macOS 13 ScreenCaptureKit app, shared scheme, recording lifecycle, persistence model, Make gates, and hosted workflow. Add fail-closed documentation contracts, then retire only the completed setup roadmap item.
+
+**Tech Stack:** Markdown, Python 3 static contracts, Swift 5, SwiftUI, ScreenCaptureKit, AVFoundation, Core Data, GNU Make, Xcode, GitHub Actions
+
+---
+
+## Status: Completed
+
+### Task 1: Add The Documentation Contract
+
+**Files:**
+- Modify: `scripts/check-capture-source.py`
+- Test: `scripts/check-capture-source.py`
+
+**Step 1: Write the failing test**
+
+Require the supported baseline, shared scheme, permission path, automatic-start boundary, capture controls, local recording behavior, verification, roadmap, history, and completed-plan evidence.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 scripts/check-capture-source.py --mode project`
+
+Expected: FAIL because the generated setup text does not separate these operating boundaries.
+
+### Task 2: Write The Setup Guide
+
+**Files:**
+- Modify: `README.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+
+**Step 1: Write minimal documentation**
+
+Document Swift 5/macOS 13, the shared `CaptureSample` scheme, local signing, Screen Recording authorization, denied-permission behavior, automatic start/stop intent, display/window and audio controls, local Documents/Core Data output, and portable/native verification.
+
+**Step 2: Run focused contracts**
+
+Run: `python3 scripts/check-capture-source.py --mode project`
+
+Expected: PASS.
+
+### Task 3: Prove Drift Fails Closed
+
+**Files:**
+- Test: `scripts/check-capture-source.py`
+
+**Step 1: Apply hostile mutations**
+
+Mutate each setup-guide, roadmap, history, and completed-plan contract in an isolated repository copy.
+
+**Step 2: Verify each mutation fails**
+
+Run the project checker after each mutation.
+
+Expected: every mutation is rejected.
+
+### Task 4: Run The Full Gate
+
+**Files:**
+- Verify: `Makefile`
+
+**Step 1: Run repository and external gates**
+
+Run: `/usr/bin/make check`
+
+Run: `cd "$(mktemp -d)" && /usr/bin/make -f /absolute/path/to/Makefile check`
+
+Expected: portable project/behavior/mutation/Make authority gates pass; hosted macOS supplies the unsigned native build.
+
+### Task 5: Commit And Ship
+
+**Files:**
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-06-26-screen-recorder-setup-guide.md`
+
+**Step 1: Record exact validation**
+
+Add mutation, local gate, hosted build, review, and manual-permission blocker evidence.
+
+**Step 2: Commit**
+
+```bash
+git add README.md VISION.md CHANGES.md scripts/check-capture-source.py docs/plans/2026-06-26-screen-recorder-setup-guide.md
+git commit -m "docs: document ScreenRecorder setup"
+```
+
+## Results
+
+- The focused project checker failed on the absent guide, then passed after the
+  source-backed documentation reconciliation.
+- All 23 isolated hostile setup-guide mutations were rejected. Two preliminary
+  harness runs stopped on an incorrectly represented wrapped Markdown fixture;
+  correcting it changed no repository file before the complete passing rerun.
+- Checkout and external-directory `/usr/bin/make check` each passed 66 Make
+  target/authority cases and 31 existing focused recording mutations; Linux
+  truthfully skipped unavailable Xcode.
+- Claims were audited against project settings, the shared scheme,
+  ScreenCaptureKit permission/configuration code, persisted stop intent,
+  Documents/Core Data output, entitlements, and the pinned workflow.
+- Live permission, source enumeration, capture, system audio, and playback
+  remain an authorized-macOS manual boundary.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -33,6 +33,7 @@ USER_STOPPED_AUTOSTART_PLAN = DOCS_PLANS / "2026-06-16-user-stopped-autostart-gu
 MENU_RECORDER_STATE_PLAN = DOCS_PLANS / "2026-06-16-menu-recorder-state-toggle.md"
 STREAM_DELEGATE_FAILURE_PLAN = DOCS_PLANS / "2026-06-17-stream-delegate-failure-cleanup.md"
 SOURCE_RECONCILIATION_PLAN = DOCS_PLANS / "2026-06-25-capture-source-reconciliation.md"
+SETUP_GUIDE_PLAN = DOCS_PLANS / "2026-06-26-screen-recorder-setup-guide.md"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
 MAKEFILE = ROOT / "Makefile"
 CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
@@ -81,6 +82,43 @@ def require_paths():
 
 def docs_plan_checks():
     errors = []
+    normalized_readme = " ".join(read_text("README.md").split())
+    for contract in (
+        "Supported macOS and Xcode Baseline",
+        "macOS 13 deployment target",
+        "Swift 5",
+        "CaptureSample",
+        "My Mac",
+        "Screen Recording Permission",
+        "Privacy & Security > Screen Recording",
+        "SCShareableContent",
+        "Automatic Start Boundary",
+        "Capture Source and Audio Controls",
+        "Exclude sample app from stream",
+        "Capture audio",
+        "Exclude app audio",
+        "Local Recording Boundary",
+        "Documents directory",
+        "UUID-named `.MOV` file",
+        "Core Data metadata",
+        "Canonical Verification",
+        "/usr/bin/make check",
+        "Hosted Native Verification",
+    ):
+        if contract not in normalized_readme:
+            errors.append(f"README setup guide must preserve: {contract}")
+    normalized_vision = " ".join(read_text("VISION.md").split())
+    if "Keep macOS/Xcode setup, Screen Recording permission, automatic-start, and local-output guidance synchronized with source" not in normalized_vision:
+        errors.append("VISION must preserve the ScreenRecorder setup-guide boundary")
+    normalized_changes = " ".join(read_text("CHANGES.md").split())
+    if "Completed the ScreenRecorder macOS/Xcode setup priority" not in normalized_changes:
+        errors.append("CHANGES must record the ScreenRecorder setup-guide reconciliation")
+    if not SETUP_GUIDE_PLAN.exists():
+        errors.append("ScreenRecorder setup guide plan is missing")
+    else:
+        plan = SETUP_GUIDE_PLAN.read_text(encoding="utf-8")
+        if "Status: Completed" not in plan or "Document ScreenRecorder's supported macOS and Xcode setup" not in plan:
+            errors.append("ScreenRecorder setup guide plan must record completed evidence")
     if not CANONICAL_PLAN.exists():
         errors.append("docs/plans/2026-06-08-screen-recorder-macos-baseline.md is missing")
     if not TIMER_RESET_PLAN.exists():


### PR DESCRIPTION
## Summary

- Document the Swift 5/macOS 13 Xcode baseline, shared scheme, destination, and local signing boundary.
- Explain Screen Recording authorization, denied-permission behavior, and persisted automatic-start intent.
- Document display/window and system-audio controls plus local Documents/Core Data output.
- Add fail-closed setup-guide contracts and retire the completed roadmap item.

## Baseline

The sample lacked one canonical setup guide tying its project settings and shared scheme to the required macOS authorization, signing, capture controls, persistence behavior, and manual verification boundary.

## Improvements

- **Documentation:** Added the supported Xcode/macOS baseline, signing setup, permission behavior, capture controls, and local output paths.
- **Tests:** Added mutation-sensitive setup-guide and source-claim contracts.
- **Security:** Documented local-only data handling and confirmed no camera, microphone, network, sharing, or export API expansion.
- **Developer experience:** Added exact project, scheme, destination, and manual verification instructions.

## Validation

- The project-mode source checker failed before the guide and passed after it was added.
- Twenty-three isolated hostile setup-guide mutations were rejected.
- `/usr/bin/make check` passed from the checkout and an unrelated working directory.
- Each full invocation passed 66 Make authority cases and 31 focused recording mutations.
- Source claims were audited against project settings, the shared scheme, permission/configuration code, persistence code, entitlements, and workflow.
- Camera, microphone, network, sharing, and export API scans plus `git diff --check` passed.
- Exact-head hosted macOS `build` and `contract` checks succeeded.

## Risk

This change documents and enforces the existing sample boundary. Live Screen Recording authorization, display/window enumeration, capture, system audio, protected-content behavior, and local playback still require an authorized Mac with synthetic non-sensitive content.

## Follow-Ups

Run the documented manual capture matrix on an authorized Mac and retain only synthetic, non-sensitive recordings and evidence.
