### PR TITLE
fix: serialize movie recorder state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ built with ScreenCaptureKit.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-screen-recorder-macos-baseline.md` for the canonical capture and recording safety baseline.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Keep `MovieRecorder` writer publication, append, cancellation, and finalization
+  handoff under its single state lock.
 - Unexpected ScreenCaptureKit delegate stops propagate through the shared
   recording cleanup path.
 - MovieRecorder exposes only its video transform at initialization; fixed audio

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,69 @@
 # Changes
 
+## 2026-06-26 19:57 PDT - P1 - Serialize movie recorder state
+
+### Summary
+
+Protected `MovieRecorder` writer state with one lock so concurrent video,
+audio, stop, and failure-cleanup paths cannot race while appending or handing
+the writer off for finalization.
+
+### Work completed
+
+- Added a private defer-unlocked state helper around writer publication and
+  sample appends.
+- Added one atomic writer handoff used by both awaited stop and cancellation.
+- Preserved first-video-sample startup and existing append-failure propagation.
+- Added a focused source contract with eight hostile synchronization mutations.
+
+### Threads
+
+- Started: none; the bounded recorder ownership defect was handled directly.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+
+- `CaptureSample/Record.swift` — serialized mutable asset-writer state.
+- `scripts/movie_recorder_state_lock_contract.py` — encoded the lock and atomic
+  handoff invariants.
+- `scripts/test_movie_recorder_state_lock_contract.py` — added eight hostile
+  regression mutations.
+- `scripts/check-capture-source.py` and
+  `scripts/test_movie_recorder_video_start_contract.py` — reconciled existing
+  finalization and first-frame checks with the locked implementation.
+- `Makefile`, repository guidance, and the completed plan — registered and
+  documented the new boundary.
+
+### Validation
+
+- RED: the focused contract rejected the unlocked baseline across writer
+  publication, append, stop, and cancellation ownership.
+- GREEN: the focused suite passes with all eight hostile mutations rejected.
+- Existing behavior checks and the four-mutation first-video-start suite pass.
+- Repository and external-root `make check` each pass 66 Make authority cases,
+  project and behavior checks, and 39 focused mutations.
+- Python compilation and `git diff --check` pass; Linux truthfully skips
+  unavailable Xcode.
+- Hosted unsigned macOS build, CodeQL, and exact-head review remain required
+  before merge.
+
+### Bugs / findings
+
+- P1: ScreenCaptureKit delivered video and audio on separate queues while stop
+  and error cleanup could concurrently clear the same unsynchronized writer
+  properties, risking a data race during append or finalization handoff.
+
+### Blockers
+
+- Live capture concurrency still requires an authorized Mac; portable checks
+  validate source ownership and mutations rather than ScreenCaptureKit timing.
+
+### Next action
+
+- Run repository and external-root verification, then require hosted build,
+  CodeQL, and exact-head review before merging.
+
 ## 2026-06-26 03:24 PDT - P2 - Document supported recorder setup
 
 ### Summary

--- a/CaptureSample/Record.swift
+++ b/CaptureSample/Record.swift
@@ -15,6 +15,8 @@ private struct FinalizingAssetWriter: @unchecked Sendable {
 
 class MovieRecorder {
 
+    private let stateLock = NSLock()
+
     private var assetWriter: AVAssetWriter?
 
     private var assetWriterVideoInput: AVAssetWriterInput?
@@ -23,10 +25,16 @@ class MovieRecorder {
 
     private let videoTransform: CGAffineTransform
 
-    private(set) var isRecording = false
+    private var isRecording = false
 
     init(videoTransform: CGAffineTransform) {
         self.videoTransform = videoTransform
+    }
+
+    private func withStateLock<Result>(_ operation: () throws -> Result) rethrows -> Result {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return try operation()
     }
 
     private func documentDirectory() -> URL? {
@@ -71,19 +79,16 @@ class MovieRecorder {
         assetWriterVideoInput.transform = videoTransform
         assetWriter.add(assetWriterVideoInput)
 
-        self.assetWriter = assetWriter
-        self.assetWriterAudioInput = assetWriterAudioInput
-        self.assetWriterVideoInput = assetWriterVideoInput
-
-        isRecording = true
+        withStateLock {
+            self.assetWriter = assetWriter
+            self.assetWriterAudioInput = assetWriterAudioInput
+            self.assetWriterVideoInput = assetWriterVideoInput
+            isRecording = true
+        }
     }
 
     func stopRecording() async -> URL? {
-        let assetWriter = self.assetWriter
-        isRecording = false
-        self.assetWriter = nil
-        assetWriterAudioInput = nil
-        assetWriterVideoInput = nil
+        let assetWriter = takeAssetWriter()
 
         guard let assetWriter = assetWriter else {
             return nil
@@ -103,55 +108,65 @@ class MovieRecorder {
         }
     }
 
-    func cancelRecording() {
-        guard let assetWriter = assetWriter else {
+    private func takeAssetWriter() -> AVAssetWriter? {
+        withStateLock {
+            let assetWriter = self.assetWriter
             isRecording = false
+            self.assetWriter = nil
+            assetWriterAudioInput = nil
+            assetWriterVideoInput = nil
+            return assetWriter
+        }
+    }
+
+    func cancelRecording() {
+        guard let assetWriter = takeAssetWriter() else {
             return
         }
 
-        isRecording = false
-        self.assetWriter = nil
-        assetWriterAudioInput = nil
-        assetWriterVideoInput = nil
         assetWriter.cancelWriting()
         try? FileManager.default.removeItem(at: assetWriter.outputURL)
     }
 
     func recordVideo(sampleBuffer: CMSampleBuffer) throws {
-        guard isRecording,
-            let assetWriter = assetWriter else {
-                return
-        }
-
-        if assetWriter.status == .unknown {
-            guard assetWriter.startWriting() else {
-                throw assetWriter.error ?? MovieRecorderError.assetWriterStartFailed
+        try withStateLock {
+            guard isRecording,
+                let assetWriter = assetWriter else {
+                    return
             }
-            assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
-        }
 
-        guard assetWriter.status == .writing,
-            let input = assetWriterVideoInput,
-            input.isReadyForMoreMediaData else {
-                return
-        }
+            if assetWriter.status == .unknown {
+                guard assetWriter.startWriting() else {
+                    throw assetWriter.error ?? MovieRecorderError.assetWriterStartFailed
+                }
+                assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+            }
 
-        guard input.append(sampleBuffer) else {
-            throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed
+            guard assetWriter.status == .writing,
+                let input = assetWriterVideoInput,
+                input.isReadyForMoreMediaData else {
+                    return
+            }
+
+            guard input.append(sampleBuffer) else {
+                throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed
+            }
         }
     }
 
     func recordAudio(sampleBuffer: CMSampleBuffer) throws {
-        guard isRecording,
-            let assetWriter = assetWriter,
-            assetWriter.status == .writing,
-            let input = assetWriterAudioInput,
-            input.isReadyForMoreMediaData else {
-                return
-        }
+        try withStateLock {
+            guard isRecording,
+                let assetWriter = assetWriter,
+                assetWriter.status == .writing,
+                let input = assetWriterAudioInput,
+                input.isReadyForMoreMediaData else {
+                    return
+            }
 
-        guard input.append(sampleBuffer) else {
-            throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed
+            guard input.append(sampleBuffer) else {
+                throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed
+            }
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ test::
 	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_menu_recorder_state_contract.py'
 	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_stream_delegate_failure_contract.py'
 	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_capture_source_reconciliation_contract.py'
+	'$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_movie_recorder_state_lock_contract.py'
 
 build:: lint
 	@if [ -x /usr/bin/xcodebuild ]; then \

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Mac with synthetic, non-sensitive content.
 - A video sample append failure follows the same cleanup path instead of
   allowing capture to continue with a failed movie writer.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Movie writer publication, audio/video append, cancellation, and finalization
+  handoff share one lock-protected state boundary.
 - Unexpected ScreenCaptureKit delegate stops propagate through the shared
   recording cleanup path so partial movies, continuations, and retained streams
   are not left active.
@@ -248,6 +250,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   menu start/stop and persisted-intent ordering contract.
 - See `docs/plans/2026-06-17-stream-delegate-failure-cleanup.md` for unexpected
   stream-stop routing through shared recording cleanup.
+- See `docs/plans/2026-06-26-movie-recorder-state-lock.md` for serialized writer
+  ownership across callback and stop paths.
 - See `docs/plans/2026-06-25-capture-source-reconciliation.md` for display
   disconnect and closed-window selection recovery.
 - See `docs/plans/2026-06-13-audio-sample-forwarding.md` for the recorded-audio

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,8 @@ Helpful reports include:
 - A video sample append failure must propagate through the same cleanup boundary
   instead of allowing capture to continue after the writer rejects a frame.
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Movie writer state is lock-protected because audio, video, explicit stop, and
+  failure cleanup can arrive from different execution contexts.
 - Unexpected ScreenCaptureKit delegate stops propagate through the shared
   recording cleanup path so partial local output is cancelled.
 - Recording finalization persists history only after the asset writer reports

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,8 @@ Priority:
 - Stop active capture when a runtime writer start failure rejects the first frame
 - Propagate video sample append failure through the existing recording cleanup path
 - Video and audio sample append failures propagate through the shared recording cleanup path.
+- Serialize movie writer publication, audio/video append, cancellation, and
+  finalization handoff through one recorder-owned state boundary
 - Unexpected ScreenCaptureKit delegate stops propagate through the shared
   recording cleanup path.
 - Remove unfinished movie files when capture setup fails

--- a/docs/plans/2026-06-26-movie-recorder-state-lock.md
+++ b/docs/plans/2026-06-26-movie-recorder-state-lock.md
@@ -1,0 +1,40 @@
+# Movie Recorder State Lock
+
+Status: Completed
+Date: 2026-06-26
+
+## Context
+
+ScreenCaptureKit sends video and audio samples to separate dispatch queues.
+Those callbacks append through one `MovieRecorder`, while explicit stop and
+failure cleanup can concurrently detach, cancel, or finalize the same mutable
+`AVAssetWriter` and input properties. The recorder had no synchronization for
+that shared state.
+
+## Decision
+
+- Give `MovieRecorder` one private `NSLock` and a defer-unlocked helper.
+- Publish the initialized writer and inputs under that lock.
+- Serialize video and audio writer-status checks and appends under the same
+  lock.
+- Atomically detach all writer state before awaited finalization or immediate
+  cancellation.
+- Keep finalization outside the lock after ownership has been detached.
+
+## Verification
+
+- RED: the new contract rejected the unlocked baseline for all required state
+  publication, append, cancellation, and stop-handoff paths.
+- GREEN: the focused contract passes and rejects eight isolated mutations.
+- Existing behavior and first-video-start contracts remain green.
+- Repository and external-root `make check` each pass 66 Make authority cases,
+  project and behavior checks, and 39 focused mutations; Linux truthfully
+  skips unavailable Xcode.
+- Hosted unsigned macOS build, CodeQL, and exact-head review remain release
+  gates.
+
+## Manual Verification
+
+On an authorized Mac, record display or window content with system audio,
+exercise explicit stop and an induced stream failure, then verify one playable
+movie or a cleaned partial file with no crash, hang, or stale recording state.

--- a/scripts/check-capture-source.py
+++ b/scripts/check-capture-source.py
@@ -482,8 +482,20 @@ def behavior_checks():
         errors.append("CaptureEngine start failures must cancel the partial movie before finishing")
     if "func stopRecording() async -> URL?" not in record:
         errors.append("MovieRecorder stop must expose an awaitable completed-or-failed output URL")
-    if "let assetWriter = self.assetWriter\n        isRecording = false\n        self.assetWriter = nil\n        assetWriterAudioInput = nil\n        assetWriterVideoInput = nil\n\n        guard let assetWriter = assetWriter else" not in record:
-        errors.append("MovieRecorder stop must clear all recorder state before handling an absent writer")
+    if "let assetWriter = takeAssetWriter()\n\n        guard let assetWriter = assetWriter else" not in record:
+        errors.append("MovieRecorder stop must atomically detach recorder state before handling an absent writer")
+    take_writer_fragments = (
+        "private func takeAssetWriter() -> AVAssetWriter?",
+        "withStateLock {",
+        "let assetWriter = self.assetWriter",
+        "isRecording = false",
+        "self.assetWriter = nil",
+        "assetWriterAudioInput = nil",
+        "assetWriterVideoInput = nil",
+        "return assetWriter",
+    )
+    if any(fragment not in record for fragment in take_writer_fragments):
+        errors.append("MovieRecorder must clear all recorder state through its locked writer handoff")
     if "guard let assetWriter = assetWriter else {\n            return nil\n        }" not in record:
         errors.append("MovieRecorder stop must complete with no URL when no writer is active")
     if "guard assetWriter.status == .completed else {" not in record:

--- a/scripts/movie_recorder_state_lock_contract.py
+++ b/scripts/movie_recorder_state_lock_contract.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+
+def _method_body(source, signature, next_signature):
+    start = source.find(signature)
+    if start < 0:
+        return None
+    end = source.find(next_signature, start)
+    if end < 0:
+        return None
+    return source[start:end]
+
+
+def validation_errors(source):
+    errors = []
+
+    if "private let stateLock = NSLock()" not in source:
+        errors.append("MovieRecorder must own a private state lock")
+    if "private var isRecording = false" not in source:
+        errors.append("MovieRecorder recording state must not expose an unlocked getter")
+
+    helper = _method_body(
+        source,
+        "private func withStateLock<Result>",
+        "    private func documentDirectory()",
+    )
+    if helper is None or not all(
+        fragment in helper
+        for fragment in (
+            "stateLock.lock()",
+            "defer { stateLock.unlock() }",
+            "return try operation()",
+        )
+    ):
+        errors.append("MovieRecorder must provide a defer-unlocked state helper")
+
+    method_contracts = (
+        (
+            "func startRecording(height: Int, width: Int) throws {",
+            "    func stopRecording() async -> URL?",
+            "withStateLock {",
+            "MovieRecorder.startRecording must publish writer state under the state lock",
+        ),
+        (
+            "func cancelRecording() {",
+            "    func recordVideo(sampleBuffer: CMSampleBuffer) throws {",
+            "takeAssetWriter()",
+            "MovieRecorder.cancelRecording must detach writer state under the state lock",
+        ),
+        (
+            "func recordVideo(sampleBuffer: CMSampleBuffer) throws {",
+            "    func recordAudio(sampleBuffer: CMSampleBuffer) throws {",
+            "try withStateLock {",
+            "MovieRecorder.recordVideo must serialize writer access under the state lock",
+        ),
+    )
+    for signature, next_signature, lock_call, message in method_contracts:
+        body = _method_body(source, signature, next_signature)
+        if body is None or lock_call not in body:
+            errors.append(message)
+
+    audio_start = source.find("func recordAudio(sampleBuffer: CMSampleBuffer) throws {")
+    audio_body = source[audio_start:] if audio_start >= 0 else None
+    if audio_body is None or "try withStateLock {" not in audio_body:
+        errors.append("MovieRecorder.recordAudio must serialize writer access under the state lock")
+
+    stop_body = _method_body(
+        source,
+        "func stopRecording() async -> URL? {",
+        "    func cancelRecording() {",
+    )
+    if stop_body is None or not all(
+        fragment in stop_body
+        for fragment in (
+            "let assetWriter = takeAssetWriter()",
+            "private func takeAssetWriter() -> AVAssetWriter?",
+        )
+    ):
+        errors.append("MovieRecorder.stopRecording must atomically detach writer state before awaiting finalization")
+
+    take_writer = _method_body(
+        source,
+        "private func takeAssetWriter() -> AVAssetWriter? {",
+        "    func cancelRecording() {",
+    )
+    if take_writer is None or not all(
+        fragment in take_writer
+        for fragment in (
+            "withStateLock {",
+            "let assetWriter = self.assetWriter",
+            "isRecording = false",
+            "self.assetWriter = nil",
+            "assetWriterAudioInput = nil",
+            "assetWriterVideoInput = nil",
+            "return assetWriter",
+        )
+    ):
+        errors.append("MovieRecorder must clear all writer state atomically")
+
+    return errors

--- a/scripts/test_movie_recorder_state_lock_contract.py
+++ b/scripts/test_movie_recorder_state_lock_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from movie_recorder_state_lock_contract import validation_errors
+
+
+ROOT = Path(__file__).resolve().parents[1]
+baseline = (ROOT / "CaptureSample" / "Record.swift").read_text(encoding="utf-8")
+
+errors = validation_errors(baseline)
+if errors:
+    raise AssertionError(f"baseline movie recorder state-lock contract invalid: {errors}")
+
+mutations = {
+    "state lock removed": baseline.replace("    private let stateLock = NSLock()\n", "", 1),
+    "recording state getter exposed": baseline.replace(
+        "    private var isRecording = false\n",
+        "    private(set) var isRecording = false\n",
+        1,
+    ),
+    "unlock defer removed": baseline.replace("        defer { stateLock.unlock() }\n", "", 1),
+    "start publication unlocked": baseline.replace("        withStateLock {\n", "        do {\n", 1),
+    "stop detachment bypassed": baseline.replace(
+        "        let assetWriter = takeAssetWriter()\n",
+        "        let assetWriter = self.assetWriter\n",
+        1,
+    ),
+    "cancel detachment unlocked": baseline.replace(
+        "        guard let assetWriter = takeAssetWriter() else {",
+        "        guard let assetWriter = self.assetWriter else {",
+        1,
+    ),
+    "video append unlocked": baseline.replace(
+        "    func recordVideo(sampleBuffer: CMSampleBuffer) throws {\n        try withStateLock {",
+        "    func recordVideo(sampleBuffer: CMSampleBuffer) throws {\n        do {",
+        1,
+    ),
+    "audio append unlocked": baseline.replace(
+        "    func recordAudio(sampleBuffer: CMSampleBuffer) throws {\n        try withStateLock {",
+        "    func recordAudio(sampleBuffer: CMSampleBuffer) throws {\n        do {",
+        1,
+    ),
+}
+
+for description, source in mutations.items():
+    if source == baseline:
+        raise AssertionError(f"{description} mutation did not alter the baseline")
+    if not validation_errors(source):
+        raise AssertionError(f"{description} mutation was accepted")
+
+print(
+    "Movie recorder state-lock contract passed "
+    f"({len(mutations)} mutations rejected)."
+)

--- a/scripts/test_movie_recorder_video_start_contract.py
+++ b/scripts/test_movie_recorder_video_start_contract.py
@@ -12,39 +12,41 @@ if errors:
     raise AssertionError(f"baseline movie recorder video-start contract invalid: {errors}")
 
 first_append_guard = (
-    "        guard assetWriter.status == .writing,\n"
-    "            let input = assetWriterVideoInput,\n"
-    "            input.isReadyForMoreMediaData else {\n"
-    "                return\n"
-    "        }\n\n"
-    "        guard input.append(sampleBuffer) else {\n"
-    "            throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed\n"
-    "        }\n"
+    "            guard assetWriter.status == .writing,\n"
+    "                let input = assetWriterVideoInput,\n"
+    "                input.isReadyForMoreMediaData else {\n"
+    "                    return\n"
+    "            }\n\n"
+    "            guard input.append(sampleBuffer) else {\n"
+    "                throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed\n"
+    "            }\n"
 )
 
 mutations = {
     "first sample hidden behind else-if": baseline.replace(
-        "        guard assetWriter.status == .writing,",
-        "        } else if assetWriter.status == .writing {\n"
-        "            guard",
+        "            guard assetWriter.status == .writing,",
+        "            } else if assetWriter.status == .writing {\n"
+        "                guard",
         1,
     ),
     "first sample append removed": baseline.replace(first_append_guard, "", 1),
     "append failure swallowed": baseline.replace(
         "guard input.append(sampleBuffer) else {\n"
-        "            throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed\n"
-        "        }",
+        "                throw assetWriter.error ?? MovieRecorderError.assetWriterAppendFailed\n"
+        "            }",
         "_ = input.append(sampleBuffer)",
         1,
     ),
     "append duplicated": baseline.replace(
         "guard input.append(sampleBuffer) else {",
-        "_ = input.append(sampleBuffer)\n        guard input.append(sampleBuffer) else {",
+        "_ = input.append(sampleBuffer)\n            guard input.append(sampleBuffer) else {",
         1,
     ),
 }
 
 for description, source in mutations.items():
+    if source == baseline:
+        raise AssertionError(f"{description} mutation did not alter the baseline")
     if not validation_errors(source):
         raise AssertionError(f"{description} mutation was accepted")
 


### PR DESCRIPTION
## Summary
- serialize `MovieRecorder` writer publication and audio/video appends behind one private state lock
- atomically detach writer state before cancellation or awaited finalization
- add a focused contract that rejects eight synchronization regressions while preserving first-video startup behavior

## Validation
- `make check`
- `make -C /tmp -f /home/gpj/.explore/repos/github.com/garethpaul/ScreenRecorderMacOS/Makefile check`
- 66 Make authority cases and 39 focused mutations per entry point
- `git diff --check`
- local Linux correctly skips unavailable Xcode; hosted unsigned macOS build remains required

## Manual verification
On an authorized Mac, record display/window content with system audio, exercise explicit stop and an induced stream failure, then verify one playable movie or cleaned partial output without a crash, hang, or stale recording state.
